### PR TITLE
gitmodules: Use HTTPS instead of git for submodule cloning

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "fixtures"]
 	path = fixtures
-	url = git@github.com:ethereum/tests.git
+	url = https://github.com/ethereum/tests.git


### PR DESCRIPTION
Travis is failing due to not knowing how to auth to github, e.g. [build log](https://travis-ci.org/pipermerriam/py-evm/builds/219093258) for PR #1.

The build machine would need a public key with github to use `git@` URL.