### PR TITLE
Create local db backend

### DIFF
--- a/evm/db/__init__.py
+++ b/evm/db/__init__.py
@@ -1,0 +1,22 @@
+import os
+
+from evm.utils.module_loading import (
+    import_string,
+)
+
+
+DEFAULT_DB_BACKEND = 'evm.db.backends.memory.MemoryDB'
+
+
+def get_db_backend_class(import_path=None):
+    if import_path is None:
+        import_path = os.environ.get(
+            'EVM_DB_BACKEND_CLASS',
+            DEFAULT_DB_BACKEND,
+        )
+    return import_string(import_path)
+
+
+def get_db_backend(import_path=None):
+    backend_class = get_db_backend_class(import_path)
+    return backend_class()

--- a/evm/db/backends/base.py
+++ b/evm/db/backends/base.py
@@ -1,0 +1,48 @@
+class BaseDB(object):
+    def get(self, key):
+        raise NotImplementedError(
+            "The `get` method must be implemented by subclasses of BaseDB"
+        )
+
+    def set(self, key, value):
+        raise NotImplementedError(
+            "The `set` method must be implemented by subclasses of BaseDB"
+        )
+
+    def exists(self, key):
+        raise NotImplementedError(
+            "The `exists` method must be implemented by subclasses of BaseDB"
+        )
+
+    def delete(self, key):
+        raise NotImplementedError(
+            "The `delete` method must be implemented by subclasses of BaseDB"
+        )
+
+    #
+    # Snapshot API
+    #
+    def snapshot(self):
+        raise NotImplementedError(
+            "The `snapshot` method must be implemented by subclasses of BaseDB"
+        )
+
+    def revert(self, snapshot):
+        raise NotImplementedError(
+            "The `revert` method must be implemented by subclasses of BaseDB"
+        )
+
+    #
+    # Dictionary API
+    #
+    def __getitem__(self, key):
+        return self.get(key)
+
+    def __setitem__(self, key, value):
+        return self.set(key, value)
+
+    def __delitem__(self, key):
+        return self.delete(key)
+
+    def __contains__(self, key):
+        return self.exists(key)

--- a/evm/db/backends/memory.py
+++ b/evm/db/backends/memory.py
@@ -1,0 +1,32 @@
+import copy
+from .base import (
+    BaseDB,
+)
+
+
+class MemoryDB(BaseDB):
+    kv_store = None
+
+    def __init__(self):
+        self.kv_store = {}
+
+    def get(self, key):
+        return self.kv_store[key]
+
+    def set(self, key, value):
+        self.kv_store[key] = value
+
+    def exists(self, key):
+        return key in self.kv_store
+
+    def delete(self, key):
+        del self.kv_store[key]
+
+    #
+    # Snapshot API
+    #
+    def snapshot(self):
+        return copy.copy(self.kv_store)
+
+    def revert(self, snapshot):
+        self.kv_store = snapshot

--- a/evm/ecc/__init__.py
+++ b/evm/ecc/__init__.py
@@ -17,6 +17,6 @@ def get_ecc_backend_class(import_path=None):
     return import_string(import_path)
 
 
-def get_ecc_backend():
-    backend_class = get_ecc_backend_class()
+def get_ecc_backend(import_path=None):
+    backend_class = get_ecc_backend_class(import_path)
     return backend_class()

--- a/tests/core/evm/test_evm.py
+++ b/tests/core/evm/test_evm.py
@@ -1,8 +1,9 @@
 import pytest
 
-from trie.db.memory import (
-    MemoryDB,
+from evm.db import (
+    get_db_backend,
 )
+
 
 from evm import constants
 from evm import EVM
@@ -25,7 +26,7 @@ def test_get_vm_class_for_block_number():
             (constants.HOMESTEAD_MAINNET_BLOCK, HomesteadVM),
         ),
     )
-    evm = evm_class(MemoryDB(), BlockHeader(1, 0, 100))
+    evm = evm_class(get_db_backend(), BlockHeader(1, 0, 100))
     assert evm.get_vm_class_for_block_number(
         constants.GENESIS_BLOCK_NUMBER,) == FrontierVM
     assert evm.get_vm_class_for_block_number(
@@ -38,7 +39,7 @@ def test_get_vm_class_for_block_number():
 
 def test_get_vm_class_for_block_number_evm_not_found():
     evm_class = EVM.configure(vm_configuration=())
-    evm = evm_class(MemoryDB(), BlockHeader(1, 0, 100))
+    evm = evm_class(get_db_backend(), BlockHeader(1, 0, 100))
     with pytest.raises(EVMNotFound):
         evm.get_vm_class_for_block_number(constants.GENESIS_BLOCK_NUMBER)
 

--- a/tests/json-fixtures/test_blockchain.py
+++ b/tests/json-fixtures/test_blockchain.py
@@ -4,8 +4,8 @@ import os
 
 import rlp
 
-from trie.db.memory import (
-    MemoryDB,
+from evm.db import (
+    get_db_backend,
 )
 
 from eth_utils import (
@@ -114,8 +114,8 @@ def test_blockchain_fixtures(fixture_name, fixture):
     # if 'genesisRLP' in fixture:
     #     assert rlp.encode(genesis_header) == fixture['genesisRLP']
 
-    db = MemoryDB()
-
+    db = get_db_backend()
+    
     evm = MainnetEVM
     # TODO: It would be great if we can figure out an API for re-configuring
     # start block numbers that was more elegant.

--- a/tests/json-fixtures/test_state.py
+++ b/tests/json-fixtures/test_state.py
@@ -2,8 +2,8 @@ import pytest
 
 import os
 
-from trie.db.memory import (
-    MemoryDB,
+from evm.db import (
+    get_db_backend,
 )
 
 from eth_utils import (
@@ -156,7 +156,7 @@ def test_state_fixtures(fixture_name, fixture):
         timestamp=fixture['env']['currentTimestamp'],
         parent_hash=fixture['env']['previousHash'],
     )
-    db = MemoryDB()
+    db = get_db_backend()
     evm = EVMForTesting(db=db, header=header)
 
     state_db = setup_state_db(fixture['pre'], evm.get_state_db())

--- a/tests/json-fixtures/test_transactions.py
+++ b/tests/json-fixtures/test_transactions.py
@@ -8,8 +8,8 @@ from eth_utils import (
 
 import os
 
-from trie.db.memory import (
-    MemoryDB,
+from evm.db import (
+    get_db_backend,
 )
 
 from eth_utils import (
@@ -60,7 +60,7 @@ def test_transaction_fixtures_smoke_test():
 )
 def test_transaction_fixtures(fixture_name, fixture):
     header = BlockHeader(1, fixture.get('blocknumber', 0), 100)
-    evm = MainnetEVM(MemoryDB(), header=header)
+    evm = MainnetEVM(get_db_backend(), header=header)
     vm = evm.get_vm()
     TransactionClass = vm.get_transaction_class()
 

--- a/tests/json-fixtures/test_vm.py
+++ b/tests/json-fixtures/test_vm.py
@@ -2,8 +2,8 @@ import pytest
 
 import os
 
-from trie.db.memory import (
-    MemoryDB,
+from evm.db import (
+    get_db_backend,
 )
 
 from eth_utils import (
@@ -125,7 +125,7 @@ EVMForTesting = EVM.configure(
     'fixture_name,fixture', FIXTURES,
 )
 def test_vm_fixtures(fixture_name, fixture):
-    db = MemoryDB()
+    db = get_db_backend()
     header = BlockHeader(
         coinbase=fixture['env']['currentCoinbase'],
         difficulty=fixture['env']['currentDifficulty'],


### PR DESCRIPTION
This PR is in response to #33 
Now py-evm uses a local `MemoryDb` as opposed to the one from `py-trie`

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/17552858/28633658-d3fdd7c8-71f1-11e7-99b2-98503a8a4e0c.png)
