### PR TITLE
try to speed up travis runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,22 @@ python:
   - "3.5"
 dist: trusty
 env:
+  global:
+    - PYTEST_ADDOPTS="-n 3"
   matrix:
     # TODO: py27
     # TODO: py34
-    - TOX_ENV=py35-blockchain-fast
-    - TOX_ENV=py35-blockchain-slow
-    - TOX_ENV=py35-core
-    - TOX_ENV=py35-state-fast
-    - TOX_ENV=py35-state-slow
-    - TOX_ENV=py35-transactions
-    - TOX_ENV=py35-vm-fast
-    - TOX_ENV=py35-vm-limits
-    - TOX_ENV=py35-coincurve
-    #- TOX_ENV=py35-vm-performance
-    - TOX_ENV=flake8
+    - TOX_POSARGS="-e py35-blockchain-fast"
+    - TOX_POSARGS="-e py35-blockchain-slow"
+    - TOX_POSARGS="-e py35-core"
+    - TOX_POSARGS="-e py35-state-fast"
+    - TOX_POSARGS="-e py35-state-slow"
+    - TOX_POSARGS="-e py35-transactions"
+    - TOX_POSARGS="-e py35-vm-fast"
+    - TOX_POSARGS="-e py35-vm-limits"
+    - TOX_POSARGS="-e py35-coincurve"
+    #- TOX_POSARGS="-e py35-vm-performance"
+    - TOX_POSARGS="-e flake8"
 cache:
   pip: true
 install:
@@ -26,6 +28,6 @@ install:
 before_script:
   - pip freeze
 script:
-  - tox -e $TOX_ENV --recreate
+  - tox $TOX_POSARGS
 after_script:
-  - cat .tox/$TOX_ENV/log/*.log
+  - cat .tox/$TOX_POSARGS/log/*.log

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 flake8==3.3.0
 pytest==3.1.2
+pytest-xdist==1.18.1
 tox==2.7.0

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,8 @@ exclude= tests/*
 
 [testenv]
 usedevelop=True
+passenv =
+    PYTEST_ADDOPTS
 commands=
     blockchain-fast: py.test {posargs:tests/json-fixtures/test_blockchain.py -m "not blockchain_slow"}
     blockchain-slow: py.test {posargs:tests/json-fixtures/test_blockchain.py -m blockchain_slow}


### PR DESCRIPTION
### What was wrong?

May be able to speed up travis test runs using xdist parallelization.

### How was it fixed?

Added `ADDOPTS="-n 3"` to split tests across 3 processes.  Lets see if it's faster.

#### Cute Animal Picture

> put a cute animal picture here.

![20466911](https://user-images.githubusercontent.com/824194/28739768-16558ff6-73bb-11e7-94dd-1a64f62e71e1.jpg)
