### PR TITLE
BlockHeader.from_parent: timestamp arg is now required

### DIFF
--- a/evm/chain.py
+++ b/evm/chain.py
@@ -117,7 +117,8 @@ class Chain(object):
 
     def create_header_from_parent(self, parent_header, **header_params):
         """
-        Passthrough helper to the current VM class.
+        Passthrough helper to the VM class of the block descending from the
+        given header.
         """
         return self.get_vm_class_for_block_number(
             block_number=parent_header.block_number + 1,

--- a/evm/rlp/headers.py
+++ b/evm/rlp/headers.py
@@ -103,17 +103,14 @@ class BlockHeader(rlp.Serializable):
                     parent,
                     gas_limit,
                     difficulty,
+                    timestamp,
                     coinbase=ZERO_ADDRESS,
-                    timestamp=None,
                     nonce=None,
                     extra_data=None):
         """
         Initialize a new block header with the `parent` header as the block's
         parent hash.
         """
-        if timestamp is None:
-            timestamp = int(time.time())
-
         header_kwargs = {
             'parent_hash': parent.hash,
             'coinbase': coinbase,

--- a/evm/vm/flavors/frontier/headers.py
+++ b/evm/vm/flavors/frontier/headers.py
@@ -59,10 +59,12 @@ def compute_frontier_difficulty(parent_header, timestamp):
 
 def create_frontier_header_from_parent(parent_header, **header_params):
     if 'difficulty' not in header_params:
-        timestamp = header_params.get('timestamp', parent_header.timestamp + 1)
+        # Use setdefault to ensure the new header has the same timestamp we use to calculate its
+        # difficulty.
+        header_params.setdefault('timestamp', parent_header.timestamp + 1)
         header_params['difficulty'] = compute_frontier_difficulty(
             parent_header,
-            timestamp,
+            header_params['timestamp'],
         )
     if 'gas_limit' not in header_params:
         header_params['gas_limit'] = compute_gas_limit(

--- a/evm/vm/flavors/homestead/headers.py
+++ b/evm/vm/flavors/homestead/headers.py
@@ -43,10 +43,12 @@ def compute_homestead_difficulty(parent_header, timestamp):
 
 def create_homestead_header_from_parent(parent_header, **header_params):
     if 'difficulty' not in header_params:
-        timestamp = header_params.get('timestamp', parent_header.timestamp + 1)
+        # Use setdefault to ensure the new header has the same timestamp we use to calculate its
+        # difficulty.
+        header_params.setdefault('timestamp', parent_header.timestamp + 1)
         header_params['difficulty'] = compute_homestead_difficulty(
             parent_header,
-            timestamp,
+            header_params['timestamp'],
         )
     return create_frontier_header_from_parent(parent_header, **header_params)
 


### PR DESCRIPTION
It was easy to accidentally create a new BlockHeader with a difficulty that did not match the
header's timestamp, which would lead to a ValidationError when trying to mine the block.



Changed BlockHeader.from_parent to make the timestamp arg required instead of defaulting to the
current time.



> put a cute animal picture here.