### PR TITLE
VM: state_db is accessible only via a contextmanager now

### DIFF
--- a/evm/chain.py
+++ b/evm/chain.py
@@ -96,12 +96,6 @@ class Chain(object):
     #
     # Convenience and Helpers
     #
-    def get_state_db(self):
-        """
-        Passthrough helper to the current VM class.
-        """
-        return self.get_vm().state_db
-
     def get_block(self):
         """
         Passthrough helper to the current VM class.

--- a/evm/logic/context.py
+++ b/evm/logic/context.py
@@ -13,7 +13,8 @@ from evm.utils.padding import (
 
 def balance(computation):
     addr = force_bytes_to_address(computation.stack.pop(type_hint=constants.BYTES))
-    balance = computation.state_db.get_balance(addr)
+    with computation.vm.state_db(read_only=True) as state_db:
+        balance = state_db.get_balance(addr)
     computation.stack.push(balance)
 
 
@@ -107,7 +108,8 @@ def gasprice(computation):
 
 def extcodesize(computation):
     account = force_bytes_to_address(computation.stack.pop(type_hint=constants.BYTES))
-    code_size = len(computation.state_db.get_code(account))
+    with computation.vm.state_db(read_only=True) as state_db:
+        code_size = len(state_db.get_code(account))
 
     computation.stack.push(code_size)
 
@@ -130,7 +132,8 @@ def extcodecopy(computation):
         reason='EXTCODECOPY: word gas cost',
     )
 
-    code = computation.state_db.get_code(account)
+    with computation.vm.state_db(read_only=True) as state_db:
+        code = state_db.get_code(account)
     code_bytes = code[code_start_position:code_start_position + size]
     padded_code_bytes = pad_right(code_bytes, size, b'\x00')
 

--- a/evm/logic/storage.py
+++ b/evm/logic/storage.py
@@ -8,10 +8,11 @@ from evm.utils.hexidecimal import (
 def sstore(computation):
     slot, value = computation.stack.pop(num_items=2, type_hint=constants.UINT256)
 
-    current_value = computation.state_db.get_storage(
-        address=computation.msg.storage_address,
-        slot=slot,
-    )
+    with computation.vm.state_db(read_only=True) as state_db:
+        current_value = state_db.get_storage(
+            address=computation.msg.storage_address,
+            slot=slot,
+        )
 
     is_currently_empty = not bool(current_value)
     is_going_to_be_empty = not bool(value)
@@ -42,18 +43,20 @@ def sstore(computation):
     if gas_refund:
         computation.gas_meter.refund_gas(gas_refund)
 
-    computation.state_db.set_storage(
-        address=computation.msg.storage_address,
-        slot=slot,
-        value=value,
-    )
+    with computation.vm.state_db() as state_db:
+        state_db.set_storage(
+            address=computation.msg.storage_address,
+            slot=slot,
+            value=value,
+        )
 
 
 def sload(computation):
     slot = computation.stack.pop(type_hint=constants.UINT256)
 
-    value = computation.state_db.get_storage(
-        address=computation.msg.storage_address,
-        slot=slot,
-    )
+    with computation.vm.state_db(read_only=True) as state_db:
+        value = state_db.get_storage(
+            address=computation.msg.storage_address,
+            slot=slot,
+        )
     computation.stack.push(value)

--- a/evm/utils/fixture_tests.py
+++ b/evm/utils/fixture_tests.py
@@ -372,7 +372,6 @@ def setup_state_db(desired_state, state_db):
         state_db.set_nonce(account, nonce)
         state_db.set_code(account, code)
         state_db.set_balance(account, balance)
-    return state_db
 
 
 def verify_state_db(expected_state, state_db):

--- a/evm/vm/computation.py
+++ b/evm/vm/computation.py
@@ -95,13 +95,6 @@ class Computation(object):
         """
         return self.msg.is_origin
 
-    @property
-    def state_db(self):
-        """
-        Convenience access to the state database
-        """
-        return self.vm.state_db
-
     #
     # Execution
     #

--- a/evm/vm/flavors/frontier/blocks.py
+++ b/evm/vm/flavors/frontier/blocks.py
@@ -278,7 +278,7 @@ class FrontierBlock(BaseBlock):
         gas_used = self.header.gas_used + tx_gas_used
 
         receipt = Receipt(
-            state_root=computation.state_db.root_hash,
+            state_root=self.header.state_root,
             gas_used=gas_used,
             logs=logs,
         )
@@ -295,7 +295,6 @@ class FrontierBlock(BaseBlock):
         self.bloom_filter |= receipt.bloom
 
         self.header.transaction_root = self.transaction_db.root_hash
-        self.header.state_root = computation.state_db.root_hash
         self.header.receipt_root = self.receipt_db.root_hash
         self.header.bloom = int(self.bloom_filter)
         self.header.gas_used = gas_used

--- a/evm/vm/flavors/frontier/validation.py
+++ b/evm/vm/flavors/frontier/validation.py
@@ -5,7 +5,8 @@ from evm.exceptions import (
 
 def validate_frontier_transaction(vm, transaction):
     gas_cost = transaction.gas * transaction.gas_price
-    sender_balance = vm.state_db.get_balance(transaction.sender)
+    with vm.state_db(read_only=True) as state_db:
+        sender_balance = state_db.get_balance(transaction.sender)
 
     if sender_balance < gas_cost:
         raise ValidationError(
@@ -20,5 +21,6 @@ def validate_frontier_transaction(vm, transaction):
     if vm.block.header.gas_used + transaction.gas > vm.block.header.gas_limit:
         raise ValidationError("Transaction exceeds gas limit")
 
-    if vm.state_db.get_nonce(transaction.sender) != transaction.nonce:
-        raise ValidationError("Invalid transaction nonce")
+    with vm.state_db(read_only=True) as state_db:
+        if state_db.get_nonce(transaction.sender) != transaction.nonce:
+            raise ValidationError("Invalid transaction nonce")

--- a/evm/vm/flavors/homestead/__init__.py
+++ b/evm/vm/flavors/homestead/__init__.py
@@ -19,13 +19,14 @@ from .headers import (
 
 
 def _apply_homestead_create_message(vm, message):
-    if vm.state_db.account_exists(message.storage_address):
-        vm.state_db.set_nonce(message.storage_address, 0)
-        vm.state_db.set_code(message.storage_address, b'')
-        vm.state_db.delete_storage(message.storage_address)
+    with vm.state_db() as state_db:
+        if state_db.account_exists(message.storage_address):
+            state_db.set_nonce(message.storage_address, 0)
+            state_db.set_code(message.storage_address, b'')
+            state_db.delete_storage(message.storage_address)
 
-    if message.sender != message.origin:
-        vm.state_db.increment_nonce(message.sender)
+        if message.sender != message.origin:
+            state_db.increment_nonce(message.sender)
 
     snapshot = vm.snapshot()
 
@@ -55,7 +56,8 @@ def _apply_homestead_create_message(vm, message):
                         encode_hex(message.storage_address),
                         contract_code,
                     )
-                computation.state_db.set_code(message.storage_address, contract_code)
+                with vm.state_db() as state_db:
+                    state_db.set_code(message.storage_address, contract_code)
         return computation
 
 

--- a/evm/vm/flavors/homestead/headers.py
+++ b/evm/vm/flavors/homestead/headers.py
@@ -68,11 +68,12 @@ def configure_homestead_header(vm, **header_params):
     # there we'd need to manually instantiate the State and update
     # header.state_root after we're done.
     if vm.support_dao_fork and header.block_number == vm.dao_fork_block_number:
-        for account in dao_drain_list:
-            account = decode_hex(account)
-            balance = vm.state_db.get_balance(account)
-            vm.state_db.delta_balance(dao_refund_contract, balance)
-            vm.state_db.set_balance(account, 0)
+        with vm.state_db() as state_db:
+            for account in dao_drain_list:
+                account = decode_hex(account)
+                balance = state_db.get_balance(account)
+                state_db.delta_balance(dao_refund_contract, balance)
+                state_db.set_balance(account, 0)
 
     return header
 

--- a/tests/core/chain-object/test_chain.py
+++ b/tests/core/chain-object/test_chain.py
@@ -20,11 +20,12 @@ def test_import_block_validation(chain):  # noqa: F811
     tx = imported_block.transactions[0]
     assert tx.value == 10
     vm = chain.get_vm()
-    assert vm.state_db.get_balance(
-        decode_hex("095e7baea6a6c7c4c2dfeb977efac326af552d87")) == tx.value
-    tx_gas = tx.gas_price * constants.GAS_TX
-    assert vm.state_db.get_balance(chain.funded_address) == (
-        chain.funded_address_initial_balance - tx.value - tx_gas)
+    with vm.state_db(read_only=True) as state_db:
+        assert state_db.get_balance(
+            decode_hex("095e7baea6a6c7c4c2dfeb977efac326af552d87")) == tx.value
+        tx_gas = tx.gas_price * constants.GAS_TX
+        assert state_db.get_balance(chain.funded_address) == (
+            chain.funded_address_initial_balance - tx.value - tx_gas)
 
 
 def test_import_block(chain_without_block_validation):  # noqa: F811

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -4,7 +4,8 @@ def new_transaction(vm, from_, to, amount, private_key, gas_price=10, gas=100000
 
     The transaction will be signed with the given private key.
     """
-    nonce = vm.state_db.get_nonce(from_)
+    with vm.state_db(read_only=True) as state_db:
+        nonce = state_db.get_nonce(from_)
     tx = vm.create_unsigned_transaction(
         nonce=nonce, gas_price=gas_price, gas=gas, to=to, value=amount, data=b'')
     return tx.as_signed_transaction(private_key)

--- a/tests/core/vm/test_vm.py
+++ b/tests/core/vm/test_vm.py
@@ -1,3 +1,5 @@
+import pytest
+
 from eth_utils import decode_hex
 
 from evm import constants
@@ -17,21 +19,21 @@ def test_apply_transaction(chain_without_block_validation):  # noqa: F811
     computation = vm.apply_transaction(tx)
     assert computation.error is None
     tx_gas = tx.gas_price * constants.GAS_TX
-    assert vm.state_db.get_balance(from_) == (
-        chain.funded_address_initial_balance - amount - tx_gas)
-    assert vm.state_db.get_balance(recipient) == amount
+    with vm.state_db(read_only=True) as state_db:
+        assert state_db.get_balance(from_) == (
+            chain.funded_address_initial_balance - amount - tx_gas)
+        assert state_db.get_balance(recipient) == amount
     block = vm.block
     assert block.transactions[tx_idx] == tx
     assert block.header.gas_used == constants.GAS_TX
-    assert block.header.state_root == computation.state_db.root_hash
 
 
 def test_mine_block(chain_without_block_validation):  # noqa: F811
     chain = chain_without_block_validation  # noqa: F811
     vm = chain.get_vm()
     block = vm.mine_block()
-    assert vm.state_db.get_balance(block.header.coinbase) == constants.BLOCK_REWARD
-    assert block.header.state_root == vm.state_db.root_hash
+    with vm.state_db(read_only=True) as state_db:
+        assert state_db.get_balance(block.header.coinbase) == constants.BLOCK_REWARD
 
 
 def test_import_block(chain_without_block_validation):  # noqa: F811
@@ -46,3 +48,21 @@ def test_import_block(chain_without_block_validation):  # noqa: F811
     parent_vm = chain.get_parent_chain(vm.block).get_vm()
     block = parent_vm.import_block(vm.block)
     assert block.transactions == [tx]
+
+
+def test_state_db(chain_without_block_validation):  # noqa: F811
+    vm = chain_without_block_validation.get_vm()
+    address = decode_hex('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0c')
+    initial_state_root = vm.block.header.state_root
+
+    with vm.state_db(read_only=True) as state_db:
+        state_db.get_balance(address)
+    assert vm.block.header.state_root == initial_state_root
+
+    with vm.state_db() as state_db:
+        state_db.set_balance(address, 10)
+    assert vm.block.header.state_root != initial_state_root
+
+    with pytest.raises(AssertionError):
+        with vm.state_db(read_only=True) as state_db:
+            state_db.set_balance(address, 0)

--- a/tests/json-fixtures/test_blockchain.py
+++ b/tests/json-fixtures/test_blockchain.py
@@ -189,4 +189,5 @@ def test_blockchain_fixtures(fixture_name, fixture):
     latest_block_hash = chain.get_canonical_block_by_number(chain.get_block().number - 1).hash
     assert latest_block_hash == fixture['lastblockhash']
 
-    verify_state_db(fixture['postState'], chain.get_state_db())
+    with chain.get_vm().state_db(read_only=True) as state_db:
+        verify_state_db(fixture['postState'], state_db)

--- a/tests/json-fixtures/test_state.py
+++ b/tests/json-fixtures/test_state.py
@@ -163,8 +163,8 @@ def test_state_fixtures(fixture_name, fixture):
     db = get_db_backend()
     chain = ChainForTesting(db=db, header=header)
 
-    state_db = setup_state_db(fixture['pre'], chain.get_state_db())
-    chain.header.state_root = state_db.root_hash
+    with chain.get_vm().state_db() as state_db:
+        setup_state_db(fixture['pre'], state_db)
 
     unsigned_transaction = chain.create_unsigned_transaction(
         nonce=fixture['transaction']['nonce'],
@@ -202,4 +202,5 @@ def test_state_fixtures(fixture_name, fixture):
         else:
             assert computation.output == expected_output
 
-    verify_state_db(fixture['post'], chain.get_state_db())
+    with chain.get_vm().state_db(read_only=True) as state_db:
+        verify_state_db(fixture['post'], state_db)


### PR DESCRIPTION
Issue #67



The state db is no longer stored as an instance variable anywehre; instead it is always accessed
via the VM.state_db() contextmanager, which takes care of updating the header's state_root on
exit.

One important thing to note is the fact that now the header's state_root is updated multiple times
during, say, the processing of a transaction (because there are multiple methods called to perform
that, and several of them make use of the state_db contextmanager), whereas before it'd only be
updated once, at the very end of the tx processing. Because of that, if we now have an uncaught
exception while adding a transaction to a block, we may end up with the wrong state_root, but
an uncaught exception there probably means we have a bug that prevents us from processing the
block anyway, so maybe ending up with the wrong state_root in this case is not an actual issue.