### PR TITLE
Create public key validation function

### DIFF
--- a/evm/utils/address.py
+++ b/evm/utils/address.py
@@ -31,5 +31,5 @@ def private_key_to_address(private_key):
 
 
 def public_key_to_address(public_key):
-    if validate_raw_public_key(public_key):
-        return keccak(public_key)[-20:]
+    validate_raw_public_key(public_key)
+    return keccak(public_key)[-20:]

--- a/evm/utils/address.py
+++ b/evm/utils/address.py
@@ -10,6 +10,10 @@ from .secp256k1 import (
     private_key_to_public_key,
 )
 
+from evm.validation import (
+    validate_raw_public_key
+)
+
 
 def force_bytes_to_address(value):
     trimmed_value = value[-20:]
@@ -27,8 +31,5 @@ def private_key_to_address(private_key):
 
 
 def public_key_to_address(public_key):
-    if len(public_key) != 64:
-        raise ValueError(
-            "Unexpected public key format: {}. Public keys must be 64 bytes long and must not "
-            "include the fixed \x04 prefix".format(public_key))
-    return keccak(public_key)[-20:]
+    if validate_raw_public_key(public_key):
+        return keccak(public_key)[-20:]

--- a/evm/utils/secp256k1.py
+++ b/evm/utils/secp256k1.py
@@ -17,15 +17,16 @@ from .padding import (
     pad32,
 )
 
+from evm.validation import (
+    validate_raw_public_key
+)
+
 
 def decode_public_key(public_key):
-    if len(public_key) != 64:
-        raise ValueError(
-            "Unexpected public key format: {}. Public keys must be 64 bytes long and must not "
-            "include the fixed \x04 prefix".format(public_key))
-    left = big_endian_to_int(public_key[0:32])
-    right = big_endian_to_int(public_key[32:64])
-    return left, right
+    if validate_raw_public_key(public_key):
+        left = big_endian_to_int(public_key[0:32])
+        right = big_endian_to_int(public_key[32:64])
+        return left, right
 
 
 def encode_raw_public_key(raw_public_key):

--- a/evm/utils/secp256k1.py
+++ b/evm/utils/secp256k1.py
@@ -23,10 +23,10 @@ from evm.validation import (
 
 
 def decode_public_key(public_key):
-    if validate_raw_public_key(public_key):
-        left = big_endian_to_int(public_key[0:32])
-        right = big_endian_to_int(public_key[32:64])
-        return left, right
+    validate_raw_public_key(public_key)
+    left = big_endian_to_int(public_key[0:32])
+    right = big_endian_to_int(public_key[32:64])
+    return left, right
 
 
 def encode_raw_public_key(raw_public_key):

--- a/evm/validation.py
+++ b/evm/validation.py
@@ -162,5 +162,6 @@ def validate_vm_block_numbers(vm_block_numbers):
 
 
 def validate_raw_public_key(value):
-    if len(value) != 64 or validate_is_bytes(value):
+    validate_is_bytes(value)
+    if len(value) != 64:
         raise ValidationError("Unexpected public key format.  Must be length 64 byte")

--- a/evm/validation.py
+++ b/evm/validation.py
@@ -159,3 +159,8 @@ def validate_vm_block_numbers(vm_block_numbers):
 
     for block_number in vm_block_numbers:
         validate_block_number(block_number)
+
+
+def validate_raw_public_key(value):
+    if len(value) != 64 or validate_is_bytes(value):
+        raise ValidationError("Unexpected public key format.  Must be length 64 byte")

--- a/tests/core/validation/test_validation.py
+++ b/tests/core/validation/test_validation.py
@@ -23,12 +23,16 @@ from evm.validation import (
     validate_lt_secpk1n,
     validate_lt_secpk1n2,
     validate_multiple_of,
+    validate_raw_public_key,
     validate_stack_item,
     validate_uint256,
     validate_unique,
     validate_vm_block_numbers,
     validate_word,
 )
+
+
+byte = b"\x00"
 
 
 @pytest.mark.parametrize(
@@ -393,3 +397,19 @@ def test_validate_vm_block_numbers(vm_block_numbers, is_valid):
     else:
         with pytest.raises(ValidationError):
             validate_vm_block_numbers(vm_block_numbers)
+
+
+@pytest.mark.parametrize(
+    "public_key_value,is_valid",
+    (
+        (byte, False),
+        (("1" * 64), False),
+        (byte * 64, True),
+    ),
+)
+def test_validate_raw_public_key(public_key_value, is_valid):
+    if is_valid:
+        validate_raw_public_key(public_key_value)
+    else:
+        with pytest.raises(ValidationError):
+            validate_raw_public_key(public_key_value)


### PR DESCRIPTION
### What was wrong?
The same code for validating public keys was used in two different places.


### How was it fixed?
That code was extracted into a new function in evm.validation.validate_raw_public_key


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/3998855/30044566-cc999874-91cb-11e7-851d-d238ffb6ae1a.png)

> put a cute animal picture here.