### PR TITLE
Implement MainnetTesterChain

### DIFF
--- a/evm/utils/chain.py
+++ b/evm/utils/chain.py
@@ -1,0 +1,20 @@
+import collections
+import operator
+
+from evm.validation import (
+    validate_vm_block_numbers,
+)
+
+
+def generate_vms_by_range(vm_configuration):
+    validate_vm_block_numbers(tuple(
+        block_number
+        for block_number, _
+        in vm_configuration
+    ))
+
+    # Organize the Chain classes by their starting blocks.
+    vms_by_range = collections.OrderedDict(
+        sorted(vm_configuration, key=operator.itemgetter(0))
+    )
+    return vms_by_range

--- a/evm/vm/flavors/__init__.py
+++ b/evm/vm/flavors/__init__.py
@@ -10,3 +10,6 @@ from .homestead import (  # noqa: F401
 from .mainnet import (  # noqa: F401
     MainnetChain,
 )
+from .tester import (  # noqa: F401
+    MainnetTesterChain,
+)

--- a/evm/vm/flavors/frontier/blocks.py
+++ b/evm/vm/flavors/frontier/blocks.py
@@ -306,11 +306,9 @@ class FrontierBlock(BaseBlock):
         self.header.uncles_hash = keccak(rlp.encode(self.uncles))
         return self
 
-    # TODO: Check with Piper what's the use case for having the mine() method allowing callsites
-    # to override header attributes, since the only place it's used we don't pass any kwarg and
-    # hence it just performs block-level validation.
     def mine(self, **kwargs):
         """
+        - `coinbase`
         - `uncles_hash`
         - `state_root`
         - `transaction_root`

--- a/evm/vm/flavors/tester/__init__.py
+++ b/evm/vm/flavors/tester/__init__.py
@@ -21,35 +21,29 @@ from evm.utils.chain import (
 )
 
 
-def chfp_method_factory(parent_class):
-    def create_tester_header_from_parent(vm_class, parent_header, **header_params):
+class MaintainGasLimitMixin(object):
+    @classmethod
+    def create_tester_header_from_parent(cls, parent_header, **header_params):
         """
-        Creates and initializes a new block header from the provided
-        `parent_header`.
+        Call the parent class method maintaining the same gas_limit as the
+        previous block.
         """
-        return parent_class.create_header_from_parent(
+        return super(MaintainGasLimitMixin, cls).create_header_from_parent(
             parent_header,
             **assoc(header_params, 'gas_limit', parent_header.gas_limit)
         )
-    return create_tester_header_from_parent
 
 
-FrontierTesterVM = BaseFrontierVM.configure(
-    name='FrontierTesterVM',
-    create_header_from_parent=classmethod(chfp_method_factory(BaseFrontierVM)),
-)
+class FrontierTesterVM(MaintainGasLimitMixin, BaseFrontierVM):
+    pass
 
 
-BaseHomesteadTesterVM = BaseHomesteadVM.configure(
-    name='HomesteadTesterVM',
-    create_header_from_parent=classmethod(chfp_method_factory(BaseHomesteadVM)),
-)
+class BaseHomesteadTesterVM(MaintainGasLimitMixin, BaseHomesteadVM):
+    pass
 
 
-EIP150TesterVM = BaseEIP150VM.configure(
-    name='EIP150TesterVM',
-    create_header_from_parent=classmethod(chfp_method_factory(BaseEIP150VM)),
-)
+class EIP150TesterVM(MaintainGasLimitMixin, BaseEIP150VM):
+    pass
 
 
 INVALID_FORK_ACTIVATION_MSG = (

--- a/evm/vm/flavors/tester/__init__.py
+++ b/evm/vm/flavors/tester/__init__.py
@@ -23,7 +23,7 @@ from evm.utils.chain import (
 
 class MaintainGasLimitMixin(object):
     @classmethod
-    def create_tester_header_from_parent(cls, parent_header, **header_params):
+    def create_header_from_parent(cls, parent_header, **header_params):
         """
         Call the parent class method maintaining the same gas_limit as the
         previous block.

--- a/evm/vm/flavors/tester/__init__.py
+++ b/evm/vm/flavors/tester/__init__.py
@@ -84,7 +84,8 @@ def _generate_vm_configuration(homestead_start_block=None,
                 dao_fork_block_number=dao_start_block,
             )
         else:
-            # Otherwise, default to the homestead_start_block block as the start of the dao_start_block fork.
+            # Otherwise, default to the homestead_start_block block as the
+            # start of the dao_start_block fork.
             HomesteadTesterVM = BaseHomesteadTesterVM.configure(
                 dao_fork_block_number=homestead_start_block,
             )

--- a/evm/vm/flavors/tester/__init__.py
+++ b/evm/vm/flavors/tester/__init__.py
@@ -1,0 +1,121 @@
+from cytoolz import (
+    assoc,
+)
+
+from eth_utils import (
+    reversed_return,
+)
+
+from evm import (
+    Chain,
+)
+
+from evm.vm.flavors import (
+    FrontierVM as BaseFrontierVM,
+    HomesteadVM as BaseHomesteadVM,
+    EIP150VM as BaseEIP150VM,
+)
+
+from evm.utils.chain import (
+    generate_vms_by_range,
+)
+
+
+def chfp_method_factory(parent_class):
+    def create_tester_header_from_parent(vm_class, parent_header, **header_params):
+        """
+        Creates and initializes a new block header from the provided
+        `parent_header`.
+        """
+        return parent_class.create_header_from_parent(
+            parent_header,
+            **assoc(header_params, 'gas_limit', parent_header.gas_limit)
+        )
+    return create_tester_header_from_parent
+
+
+FrontierTesterVM = BaseFrontierVM.configure(
+    name='FrontierTesterVM',
+    create_header_from_parent=classmethod(chfp_method_factory(BaseFrontierVM)),
+)
+
+
+BaseHomesteadTesterVM = BaseHomesteadVM.configure(
+    name='HomesteadTesterVM',
+    create_header_from_parent=classmethod(chfp_method_factory(BaseHomesteadVM)),
+)
+
+
+EIP150TesterVM = BaseEIP150VM.configure(
+    name='EIP150TesterVM',
+    create_header_from_parent=classmethod(chfp_method_factory(BaseEIP150VM)),
+)
+
+
+INVALID_FORK_ACTIVATION_MSG = (
+    "The {0}-fork activation block may not be null if the {1}-fork block "
+    "is non null"
+)
+
+
+@reversed_return
+def _generate_vm_configuration(homestead=None, dao=None, anti_dos=None):
+    # If no explicit configuration has been passed, configure the vm to start
+    # with the latest fork rules at block 0
+    if anti_dos is None and homestead is None:
+        yield (0, EIP150TesterVM)
+
+    if anti_dos is not None:
+        yield (anti_dos, EIP150TesterVM)
+
+        # If the EIP150 rules do not start at block 0 and homestead has not
+        # been configured for a specific block, configure homestead to start at
+        # block 0.
+        if anti_dos > 0 and homestead is None:
+            HomesteadTesterVM = BaseHomesteadTesterVM.configure(
+                dao_fork_block_number=0,
+            )
+            yield (0, HomesteadTesterVM)
+
+    if homestead is not None:
+        if dao is False:
+            # If dao support has explicitely been configured as `False` then
+            # mark the HomesteadTesterVM as not supporting the fork.
+            HomesteadTesterVM = BaseHomesteadTesterVM.configure(support_dao_fork=False)
+        elif dao is not None:
+            # Otherwise, if a specific dao fork block has been set, use it.
+            HomesteadTesterVM = BaseHomesteadTesterVM.configure(dao_fork_block_number=dao)
+        else:
+            # Otherwise, default to the homestead block as the start of the dao fork.
+            HomesteadTesterVM = BaseHomesteadTesterVM.configure(dao_fork_block_number=homestead)
+        yield (homestead, HomesteadTesterVM)
+
+        # If the homestead block is configured to start after block 0, set the
+        # frontier rules to start at block 0.
+        if homestead > 0:
+            yield (0, FrontierTesterVM)
+
+
+BaseMainnetTesterChain = Chain.configure(
+    'MainnetTesterChain',
+    vm_configuration=_generate_vm_configuration()
+)
+
+
+class MainnetTesterChain(BaseMainnetTesterChain):
+    def validate_seal(self, block):
+        """
+        We don't validate the proof of work seal on the tester chain.
+        """
+        pass
+
+    def configure_forks(self, homestead=None, dao=None, anti_dos=0):
+        """
+        TODO: add support for state_cleanup
+        """
+        vm_configuration = _generate_vm_configuration(
+            homestead=homestead,
+            dao=dao,
+            anti_dos=anti_dos,
+        )
+        self.vms_by_range = generate_vms_by_range(vm_configuration)

--- a/evm/vm/flavors/tester/__init__.py
+++ b/evm/vm/flavors/tester/__init__.py
@@ -53,40 +53,46 @@ INVALID_FORK_ACTIVATION_MSG = (
 
 
 @reversed_return
-def _generate_vm_configuration(homestead=None, dao=None, anti_dos=None):
+def _generate_vm_configuration(homestead_start_block=None,
+                               dao_start_block=None,
+                               eip150_start_block=None):
     # If no explicit configuration has been passed, configure the vm to start
     # with the latest fork rules at block 0
-    if anti_dos is None and homestead is None:
+    if eip150_start_block is None and homestead_start_block is None:
         yield (0, EIP150TesterVM)
 
-    if anti_dos is not None:
-        yield (anti_dos, EIP150TesterVM)
+    if eip150_start_block is not None:
+        yield (eip150_start_block, EIP150TesterVM)
 
-        # If the EIP150 rules do not start at block 0 and homestead has not
-        # been configured for a specific block, configure homestead to start at
+        # If the EIP150 rules do not start at block 0 and homestead_start_block has not
+        # been configured for a specific block, configure homestead_start_block to start at
         # block 0.
-        if anti_dos > 0 and homestead is None:
+        if eip150_start_block > 0 and homestead_start_block is None:
             HomesteadTesterVM = BaseHomesteadTesterVM.configure(
                 dao_fork_block_number=0,
             )
             yield (0, HomesteadTesterVM)
 
-    if homestead is not None:
-        if dao is False:
-            # If dao support has explicitely been configured as `False` then
+    if homestead_start_block is not None:
+        if dao_start_block is False:
+            # If dao_start_block support has explicitely been configured as `False` then
             # mark the HomesteadTesterVM as not supporting the fork.
             HomesteadTesterVM = BaseHomesteadTesterVM.configure(support_dao_fork=False)
-        elif dao is not None:
-            # Otherwise, if a specific dao fork block has been set, use it.
-            HomesteadTesterVM = BaseHomesteadTesterVM.configure(dao_fork_block_number=dao)
+        elif dao_start_block is not None:
+            # Otherwise, if a specific dao_start_block fork block has been set, use it.
+            HomesteadTesterVM = BaseHomesteadTesterVM.configure(
+                dao_fork_block_number=dao_start_block,
+            )
         else:
-            # Otherwise, default to the homestead block as the start of the dao fork.
-            HomesteadTesterVM = BaseHomesteadTesterVM.configure(dao_fork_block_number=homestead)
-        yield (homestead, HomesteadTesterVM)
+            # Otherwise, default to the homestead_start_block block as the start of the dao_start_block fork.
+            HomesteadTesterVM = BaseHomesteadTesterVM.configure(
+                dao_fork_block_number=homestead_start_block,
+            )
+        yield (homestead_start_block, HomesteadTesterVM)
 
-        # If the homestead block is configured to start after block 0, set the
+        # If the homestead_start_block block is configured to start after block 0, set the
         # frontier rules to start at block 0.
-        if homestead > 0:
+        if homestead_start_block > 0:
             yield (0, FrontierTesterVM)
 
 
@@ -103,13 +109,16 @@ class MainnetTesterChain(BaseMainnetTesterChain):
         """
         pass
 
-    def configure_forks(self, homestead=None, dao=None, anti_dos=0):
+    def configure_forks(self,
+                        homestead_start_block=None,
+                        dao_start_block=None,
+                        eip150_start_block=0):
         """
         TODO: add support for state_cleanup
         """
         vm_configuration = _generate_vm_configuration(
-            homestead=homestead,
-            dao=dao,
-            anti_dos=anti_dos,
+            homestead_start_block=homestead_start_block,
+            dao_start_block=dao_start_block,
+            eip150_start_block=eip150_start_block,
         )
         self.vms_by_range = generate_vms_by_range(vm_configuration)

--- a/tests/core/tester/test_generate_vm_configuration.py
+++ b/tests/core/tester/test_generate_vm_configuration.py
@@ -1,0 +1,71 @@
+import pytest
+
+import enum
+
+from evm.vm.flavors.tester import (
+    _generate_vm_configuration,
+)
+
+
+class Forks(enum.Enum):
+    Frontier = 0
+    Homestead = 1
+    EIP150 = 2
+
+
+@pytest.mark.parametrize(
+    "kwargs,expected",
+    (
+        (
+            dict(),
+            ((0, Forks.EIP150),),
+        ),
+        (
+            dict(eip150_start_block=1),
+            ((0, Forks.Homestead), (1, Forks.EIP150)),
+        ),
+        (
+            dict(homestead_start_block=1),
+            ((0, Forks.Frontier), (1, Forks.Homestead)),
+        ),
+        (
+            dict(homestead_start_block=1, dao_start_block=2),
+            ((0, Forks.Frontier), (1, Forks.Homestead)),
+        ),
+        (
+            dict(homestead_start_block=1, dao_start_block=False),
+            ((0, Forks.Frontier), (1, Forks.Homestead)),
+        ),
+        (
+            dict(homestead_start_block=1, eip150_start_block=2),
+            ((0, Forks.Frontier), (1, Forks.Homestead), (2, Forks.EIP150)),
+        ),
+    ),
+)
+def test_generate_vm_configuration(kwargs, expected):
+    actual = _generate_vm_configuration(**kwargs)
+    assert len(actual) == len(expected)
+
+    for left, right in zip(actual, expected):
+        left_block, left_vm = left
+        right_block, right_vm = right
+
+        assert left_block == right_block
+
+        if right_vm == Forks.Frontier:
+            assert 'Frontier' in left_vm.__name__
+        elif right_vm == Forks.Homestead:
+            assert 'Homestead' in left_vm.__name__
+            dao_start_block = kwargs.get('dao_start_block')
+            if dao_start_block is False:
+                assert left_vm.support_dao_fork is False
+            elif dao_start_block is None:
+                assert left_vm.support_dao_fork is True
+                assert left_vm.dao_fork_block_number == right_block
+            else:
+                assert left_vm.support_dao_fork is True
+                assert left_vm.dao_fork_block_number == dao_start_block
+        elif right_vm == Forks.EIP150:
+            assert 'EIP150' in left_vm.__name__
+        else:
+            assert False, "Invariant"


### PR DESCRIPTION
Blocker for: https://github.com/pipermerriam/ethereum-tester/pull/14

### What was wrong?

Py-EVM needs a *tester* chain that can be used with testing.  Primary features needed are:

* bypass POW validation
* easy configuration for starting blocks for the various hard forks
* easy initialization of the chain with custom state

### How was it fixed?

Added a new `Chain` subclass under `evm.vm.flavors.tester` with these properties.

#### Cute Animal Picture

![531652_15a5d09296b0674673641d8e449a26d5_large](https://user-images.githubusercontent.com/824194/30946453-629e1618-a3c1-11e7-88d8-f675a3455bb1.jpg)
