### PR TITLE
Piper/state db journalling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ env:
     - TOX_POSARGS="-e py35-transactions"
     - TOX_POSARGS="-e py35-vm-fast"
     - TOX_POSARGS="-e py35-vm-limits"
-    - TOX_POSARGS="-e py35-leveldb"
     - TOX_POSARGS="-e py35-p2p"
+    - TOX_POSARGS="-e py35-database"
     #- TOX_POSARGS="-e py35-vm-performance"
     - TOX_POSARGS="-e flake8"
 cache:

--- a/evm/chain.py
+++ b/evm/chain.py
@@ -44,7 +44,7 @@ from evm.utils.hexadecimal import (
 )
 from evm.utils.rlp import diff_rlp_object
 
-from evm.state import State
+from evm.db.state import State
 
 
 class Chain(object):

--- a/evm/db/backends/base.py
+++ b/evm/db/backends/base.py
@@ -20,19 +20,6 @@ class BaseDB(object):
         )
 
     #
-    # Snapshot API
-    #
-    def snapshot(self):
-        raise NotImplementedError(
-            "The `snapshot` method must be implemented by subclasses of BaseDB"
-        )
-
-    def revert(self, snapshot):
-        raise NotImplementedError(
-            "The `revert` method must be implemented by subclasses of BaseDB"
-        )
-
-    #
     # Dictionary API
     #
     def __getitem__(self, key):

--- a/evm/db/backends/level.py
+++ b/evm/db/backends/level.py
@@ -1,4 +1,5 @@
 import shutil
+
 from .base import (
     BaseDB,
 )
@@ -32,29 +33,6 @@ class LevelDB(BaseDB):
     def delete(self, key):
         self.db.Delete(key)
 
-    #
-    # Snapshot API
-    #
-    def snapshot(self):
-        return Snapshot(self.db.CreateSnapshot())
-
-    def revert(self, snapshot):
-        for item in self.db.RangeIter(include_value=False):
-            self.db.Delete(item)
-        for key, val in snapshot.items():
-            self.db.Put(key, val)
-
     # Clears the leveldb
     def __del__(self):
         shutil.rmtree(self.db_path, ignore_errors=True)
-
-
-class Snapshot(object):
-    def __init__(self, snapshot):
-        self.db = snapshot
-
-    def get(self, key):
-        return self.db.Get(key)
-
-    def items(self):
-        return self.db.RangeIter(include_value=True, reverse=True)

--- a/evm/db/backends/memory.py
+++ b/evm/db/backends/memory.py
@@ -1,4 +1,3 @@
-import copy
 from .base import (
     BaseDB,
 )
@@ -21,12 +20,3 @@ class MemoryDB(BaseDB):
 
     def delete(self, key):
         del self.kv_store[key]
-
-    #
-    # Snapshot API
-    #
-    def snapshot(self):
-        return copy.copy(self.kv_store)
-
-    def revert(self, snapshot):
-        self.kv_store = snapshot

--- a/evm/db/hash_trie.py
+++ b/evm/db/hash_trie.py
@@ -1,0 +1,30 @@
+from evm.utils.keccak import (
+    keccak,
+)
+
+
+class HashTrie(object):
+    _trie = None
+
+    def __init__(self, trie):
+        self._trie = trie
+
+    def __setitem__(self, key, value):
+        self._trie[keccak(key)] = value
+
+    def __getitem__(self, key):
+        return self._trie[keccak(key)]
+
+    def __delitem__(self, key):
+        del self._trie[keccak(key)]
+
+    def __contains__(self, key):
+        return keccak(key) in self._trie
+
+    @property
+    def root_hash(self):
+        return self._trie.root_hash
+
+    @root_hash.setter
+    def root_hash(self, value):
+        self._trie.root_hash = value

--- a/evm/db/journal.py
+++ b/evm/db/journal.py
@@ -59,27 +59,27 @@ class JournalDB(BaseDB):
     #
     # Snapshot API
     #
-    def _validate_snapshot(self, snapshot):
-        validate_is_integer(snapshot, title="Journal index")
-        validate_gte(snapshot, 0, title="Journal index")
-        validate_lte(snapshot, len(self.journal), title="Journal index")
+    def _validate_journal_index(self, journal_index):
+        validate_is_integer(journal_index, title="Journal index")
+        validate_gte(journal_index, 0, title="Journal index")
+        validate_lte(journal_index, len(self.journal), title="Journal index")
 
     def snapshot(self):
         return len(self.journal)
 
-    def revert(self, snapshot):
-        self._validate_snapshot(snapshot)
+    def revert(self, journal_index):
+        self._validate_journal_index(journal_index)
 
-        while len(self.journal) > snapshot:
+        while len(self.journal) > journal_index:
             key, previous_value = self.journal.pop()
             if previous_value is None:
                 self.wrapped_db.delete(key)
             else:
                 self.wrapped_db.set(key, previous_value)
 
-    def clear_journal(self, snapshot):
-        self._validate_snapshot(snapshot)
-        self.journal = self.journal[snapshot:]
+    def clear_journal(self, journal_index):
+        self._validate_journal_index(journal_index)
+        self.journal = self.journal[journal_index:]
 
     #
     # Dictionary API

--- a/evm/db/journal.py
+++ b/evm/db/journal.py
@@ -59,13 +59,16 @@ class JournalDB(BaseDB):
     #
     # Snapshot API
     #
+    def _validate_snapshot(self, snapshot):
+        validate_is_integer(snapshot, title="Journal index")
+        validate_gte(snapshot, 0, title="Journal index")
+        validate_lte(snapshot, len(self.journal), title="Journal index")
+
     def snapshot(self):
         return len(self.journal)
 
     def revert(self, snapshot):
-        validate_is_integer(snapshot, title="Journal index")
-        validate_gte(snapshot, 0, title="Journal index")
-        validate_lte(snapshot, len(self.journal), title="Journal index")
+        self._validate_snapshot(snapshot)
 
         while len(self.journal) > snapshot:
             key, previous_value = self.journal.pop()
@@ -74,8 +77,9 @@ class JournalDB(BaseDB):
             else:
                 self.wrapped_db.set(key, previous_value)
 
-    def clear_journal(self):
-        self.journal = []
+    def clear_journal(self, snapshot):
+        self._validate_snapshot(snapshot)
+        self.journal = self.journal[snapshot:]
 
     #
     # Dictionary API

--- a/evm/db/journal.py
+++ b/evm/db/journal.py
@@ -1,0 +1,93 @@
+from evm.db.backends.base import BaseDB
+
+from evm.validation import (
+    validate_gte,
+    validate_is_integer,
+    validate_lte,
+)
+
+
+class JournalDB(BaseDB):
+    """
+    A wrapper around the basic DB objects that keeps a journal of all changes.
+    Snapshots are simply indices into the list of journal entries.  Reversion
+    involves replaying the journal entries in reverse until we reach the
+    snapshot indices.
+
+    This allows for linear runtime reversions to the state database.
+    """
+    wrapped_db = None
+    journal = None
+
+    def __init__(self, wrapped_db):
+        self.wrapped_db = wrapped_db
+        self.journal = []
+
+    def get(self, key):
+        return self.wrapped_db.get(key)
+
+    def set(self, key, value):
+        """
+        - replacing an existing value
+        - setting a value that does not exist
+        """
+        try:
+            current_value = self.wrapped_db.get(key)
+        except KeyError:
+            current_value = None
+
+        if current_value != value:
+            # only journal `set` operations that change the value.
+            self.journal.append((key, current_value))
+
+        return self.wrapped_db.set(key, value)
+
+    def exists(self, key):
+        return self.wrapped_db.exists(key)
+
+    def delete(self, key):
+        try:
+            current_value = self.wrapped_db.get(key)
+        except KeyError:
+            # no state change so skip journaling
+            pass
+        else:
+            self.journal.append((key, current_value))
+
+        return self.wrapped_db.delete(key)
+
+    #
+    # Snapshot API
+    #
+    def snapshot(self):
+        return len(self.journal)
+
+    def revert(self, snapshot):
+        validate_is_integer(snapshot, title="Journal index")
+        validate_gte(snapshot, 0, title="Journal index")
+        validate_lte(snapshot, len(self.journal), title="Journal index")
+
+        while len(self.journal) > snapshot:
+            key, previous_value = self.journal.pop()
+            if previous_value is None:
+                self.wrapped_db.delete(key)
+            else:
+                self.wrapped_db.set(key, previous_value)
+
+    def clear_journal(self):
+        self.journal = []
+
+    #
+    # Dictionary API
+    #
+    def __getitem__(self, key):
+        return self.get(key)
+
+    def __setitem__(self, key, value):
+        return self.set(key, value)
+
+    def __delitem__(self, key):
+        return self.delete(key)
+
+    def __contains__(self, key):
+        return self.exists(key)

--- a/evm/db/journal.py
+++ b/evm/db/journal.py
@@ -105,11 +105,17 @@ class Journal(object):
 class JournalDB(BaseDB):
     """
     A wrapper around the basic DB objects that keeps a journal of all changes.
-    Snapshots are simply indices into the list of journal entries.  Reversion
-    involves replaying the journal entries in reverse until we reach the
-    snapshot indices.
+    Each time a snapshot is taken, the underlying journal creates a new
+    checkpoint.  The journal then keeps track of the original value for any
+    keys changed.  Reverting to a checkpoint involves merging the original key
+    data from any subsequent checkpoints into the given checkpoint giving
+    precidence earlier checkpoints.  Then the keys from this merged data set
+    are reset to their original values.
 
-    This allows for linear runtime reversions to the state database.
+    The added memory footprint for a JournalDB is one key/value stored per
+    database key which is changed.  Subsequent changes to the same key within
+    the same checkpoint will not increase the journal size since we only need
+    to track the original value for any given key within any given checkpoint.
     """
     wrapped_db = None
     journal = None

--- a/evm/db/state.py
+++ b/evm/db/state.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import logging
 
 import rlp
@@ -29,36 +31,7 @@ from evm.utils.padding import (
     pad32,
 )
 
-
-class HashTrie(object):
-    _trie = None
-
-    logger = logging.getLogger('evm.state.HashTrie')
-
-    def __init__(self, trie):
-        self._trie = trie
-
-    def __setitem__(self, key, value):
-        self._trie[keccak(key)] = value
-
-    def __getitem__(self, key):
-        return self._trie[keccak(key)]
-
-    def __delitem__(self, key):
-        del self._trie[keccak(key)]
-
-    def __contains__(self, key):
-        return keccak(key) in self._trie
-
-    @property
-    def root_hash(self):
-        return self._trie.root_hash
-
-    def snapshot(self):
-        return self._trie.snapshot()
-
-    def revert(self, snapshot):
-        return self._trie.revert(snapshot)
+from .hash_trie import HashTrie
 
 
 class State(object):
@@ -80,6 +53,10 @@ class State(object):
     @property
     def root_hash(self):
         return self._trie.root_hash
+
+    @root_hash.setter
+    def root_hash(self, value):
+        self._trie.root_hash = value
 
     def set_storage(self, address, slot, value):
         validate_uint256(value, title="Storage Value")
@@ -197,15 +174,6 @@ class State(object):
     def increment_nonce(self, address):
         current_nonce = self.get_nonce(address)
         self.set_nonce(address, current_nonce + 1)
-
-    #
-    # Internal
-    #
-    def snapshot(self):
-        return self._trie.snapshot()
-
-    def revert(self, snapshot):
-        return self._trie.revert(snapshot)
 
     #
     # Internal

--- a/evm/db/state.py
+++ b/evm/db/state.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import logging
 
 import rlp

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -276,8 +276,9 @@ class VM(object):
             # now roll the underlying database back
             self.journal_db.revert(journal_index)
 
-    def commit(self):
-        self.journal_db.clear_journal()
+    def commit(self, snapshot):
+        _, journal_index = snapshot
+        self.journal_db.clear_journal(journal_index)
 
     #
     # Opcode API

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -261,7 +261,7 @@ class VM(object):
         Perform a full snapshot of the current state of the VM.
 
         Snapshots are a combination of the state_root at the time of the
-        snapshot and the indices of the journaled DB.
+        snapshot and the checkpoint_id returned from the journaled DB.
         """
         return (self.block.header.state_root, self.journal_db.snapshot())
 
@@ -269,13 +269,13 @@ class VM(object):
         """
         Revert the VM to the state at the snapshot
         """
-        state_root, journal_index = snapshot
+        state_root, checkpoint_id = snapshot
 
         with self.state_db() as state_db:
             # first revert the database state root.
             state_db.root_hash = state_root
             # now roll the underlying database back
-            self.journal_db.revert(journal_index)
+            self.journal_db.revert(checkpoint_id)
 
     def commit(self, snapshot):
         """

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -8,11 +8,14 @@ from evm.constants import (
     NEPHEW_REWARD,
     UNCLE_DEPTH_PENALTY_FACTOR,
 )
+from evm.db.journal import (
+    JournalDB,
+)
+from evm.db.state import (
+    State,
+)
 from evm.logic.invalid import (
     InvalidOpcode,
-)
-from evm.state import (
-    State,
 )
 
 from evm.utils.blocks import (
@@ -37,6 +40,7 @@ class VM(object):
             raise ValueError("VM classes must have a `db`")
 
         self.db = db
+        self.journal_db = JournalDB(self.db)
 
         block_class = self.get_block_class()
         self.block = block_class.from_header(header=header, db=db)
@@ -59,7 +63,7 @@ class VM(object):
 
     @contextmanager
     def state_db(self, read_only=False):
-        state = State(db=self.db, root_hash=self.block.header.state_root)
+        state = State(db=self.journal_db, root_hash=self.block.header.state_root)
         yield state
         if read_only:
             # TODO: This is a bit of a hack; ideally we should raise an error whenever the
@@ -255,19 +259,25 @@ class VM(object):
         """
         Perform a full snapshot of the current state of the VM.
 
-        TODO: This needs to do more than just snapshot the state_db but this is a start.
+        Snapshots are a combination of the state_root at the time of the
+        snapshot and the indices of the journaled DB.
         """
-        with self.state_db(read_only=True) as state_db:
-            return state_db.snapshot()
+        return (self.block.header.state_root, self.journal_db.snapshot())
 
     def revert(self, snapshot):
         """
-        Revert the VM to the state
-
-        TODO: This needs to do more than just snapshot the state_db but this is a start.
+        Revert the VM to the state at the snapshot
         """
+        state_root, journal_index = snapshot
+
         with self.state_db() as state_db:
-            return state_db.revert(snapshot)
+            # first revert the database state root.
+            state_db.root_hash = state_root
+            # now roll the underlying database back
+            self.journal_db.revert(journal_index)
+
+    def commit(self):
+        self.journal_db.clear_journal()
 
     #
     # Opcode API

--- a/evm/vm/flavors/frontier/__init__.py
+++ b/evm/vm/flavors/frontier/__init__.py
@@ -221,6 +221,7 @@ def _apply_frontier_message(vm, message):
 
     if computation.error:
         vm.revert(snapshot)
+
     return computation
 
 

--- a/evm/vm/flavors/frontier/__init__.py
+++ b/evm/vm/flavors/frontier/__init__.py
@@ -221,6 +221,8 @@ def _apply_frontier_message(vm, message):
 
     if computation.error:
         vm.revert(snapshot)
+    else:
+        vm.commit(snapshot)
 
     return computation
 

--- a/evm/vm/flavors/homestead/__init__.py
+++ b/evm/vm/flavors/homestead/__init__.py
@@ -57,9 +57,12 @@ def _apply_homestead_create_message(vm, message):
                         encode_hex(message.storage_address),
                         contract_code,
                     )
+
                 with vm.state_db() as state_db:
                     state_db.set_code(message.storage_address, contract_code)
-        vm.commit(snapshot)
+                vm.commit(snapshot)
+        else:
+            vm.commit(snapshot)
         return computation
 
 

--- a/evm/vm/flavors/homestead/__init__.py
+++ b/evm/vm/flavors/homestead/__init__.py
@@ -33,6 +33,7 @@ def _apply_homestead_create_message(vm, message):
     computation = vm.apply_message(message)
 
     if computation.error:
+        vm.commit(snapshot)
         return computation
     else:
         contract_code = computation.output
@@ -58,6 +59,7 @@ def _apply_homestead_create_message(vm, message):
                     )
                 with vm.state_db() as state_db:
                     state_db.set_code(message.storage_address, contract_code)
+        vm.commit(snapshot)
         return computation
 
 

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ setup(
         "ethereum-utils>=0.2.0",
         "pyethash>=0.1.27",
         "rlp==0.4.7",
-        "trie==0.2.4",
         "ethereum-keys==0.1.0a6",
+        "trie>=0.3.0",
     ],
     extra_require={
         'leveldb': [

--- a/tests/database/test_journal_db.py
+++ b/tests/database/test_journal_db.py
@@ -1,0 +1,89 @@
+import pytest
+from evm.db.backends.memory import MemoryDB
+from evm.db.journal import JournalDB
+
+
+@pytest.fixture
+def memory_db():
+    return MemoryDB()
+
+
+@pytest.fixture
+def journal_db(memory_db):
+    return JournalDB(memory_db)
+
+
+def test_set_and_get(journal_db):
+    journal_db.set(b'1', b'test')
+
+    assert journal_db.get(b'1') == b'test'
+
+
+def test_get_non_existent_value(journal_db):
+    with pytest.raises(KeyError):
+        journal_db.get(b'does-not-exist')
+
+
+def test_delete_non_existent_value(journal_db):
+    with pytest.raises(KeyError):
+        journal_db.delete(b'does-not-exist')
+
+
+def test_snapshot_and_revert_with_set(journal_db):
+    journal_db.set(b'1', b'test-a')
+
+    assert journal_db.get(b'1') == b'test-a'
+
+    snapshot = journal_db.snapshot()
+
+    journal_db.set(b'1', b'test-b')
+
+    assert journal_db.get(b'1') == b'test-b'
+
+    journal_db.revert(snapshot)
+
+    assert journal_db.get(b'1') == b'test-a'
+
+
+def test_snapshot_and_revert_with_delete(journal_db):
+    journal_db.set(b'1', b'test-a')
+
+    assert journal_db.exists(b'1') is True
+    assert journal_db.get(b'1') == b'test-a'
+
+    snapshot = journal_db.snapshot()
+
+    journal_db.delete(b'1')
+
+    assert journal_db.exists(b'1') is False
+
+    journal_db.revert(snapshot)
+
+    assert journal_db.exists(b'1') is True
+    assert journal_db.get(b'1') == b'test-a'
+
+
+def test_revert_clears_reverted_journal_entries(journal_db):
+    journal_db.set(b'1', b'test-a')
+
+    assert journal_db.get(b'1') == b'test-a'
+
+    snapshot = journal_db.snapshot()
+
+    journal_db.set(b'1', b'test-b')
+    journal_db.delete(b'1')
+    journal_db.set(b'1', b'test-c')
+
+    assert journal_db.get(b'1') == b'test-c'
+
+    journal_db.revert(snapshot)
+
+    assert journal_db.get(b'1') == b'test-a'
+
+    journal_db.delete(b'1')
+
+    assert journal_db.exists(b'1') is False
+
+    journal_db.revert(snapshot)
+
+    assert journal_db.get(b'1') == b'test-a'

--- a/tests/database/test_journal_db.py
+++ b/tests/database/test_journal_db.py
@@ -68,7 +68,7 @@ def test_revert_clears_reverted_journal_entries(journal_db):
 
     assert journal_db.get(b'1') == b'test-a'
 
-    snapshot = journal_db.snapshot()
+    snapshot_a = journal_db.snapshot()
 
     journal_db.set(b'1', b'test-b')
     journal_db.delete(b'1')
@@ -76,14 +76,22 @@ def test_revert_clears_reverted_journal_entries(journal_db):
 
     assert journal_db.get(b'1') == b'test-c'
 
-    journal_db.revert(snapshot)
+    snapshot_b = journal_db.snapshot()
 
-    assert journal_db.get(b'1') == b'test-a'
+    journal_db.set(b'1', b'test-d')
+    journal_db.delete(b'1')
+    journal_db.set(b'1', b'test-e')
+
+    assert journal_db.get(b'1') == b'test-e'
+
+    journal_db.revert(snapshot_b)
+
+    assert journal_db.get(b'1') == b'test-c'
 
     journal_db.delete(b'1')
 
     assert journal_db.exists(b'1') is False
 
-    journal_db.revert(snapshot)
+    journal_db.revert(snapshot_a)
 
     assert journal_db.get(b'1') == b'test-a'

--- a/tests/database/test_journal_db.py
+++ b/tests/database/test_journal_db.py
@@ -4,13 +4,8 @@ from evm.db.journal import JournalDB
 
 
 @pytest.fixture
-def memory_db():
-    return MemoryDB()
-
-
-@pytest.fixture
-def journal_db(memory_db):
-    return JournalDB(memory_db)
+def journal_db():
+    return JournalDB(MemoryDB())
 
 
 def test_set_and_get(journal_db):

--- a/tests/database/test_leveldb_db_backend.py
+++ b/tests/database/test_leveldb_db_backend.py
@@ -57,14 +57,3 @@ def test_delete(level_db, memory_db):
     level_db.delete(b'1')
     memory_db.delete(b'1')
     assert level_db.exists(b'1') == memory_db.exists(b'1')
-
-
-def test_snapshot_and_revert(level_db):
-    snapshot = level_db.snapshot()
-    level_db.set(b'1', b'1')
-    assert level_db.get(b'1')
-    with pytest.raises(KeyError):
-        snapshot.get(b'1')
-    level_db.revert(snapshot)
-    with pytest.raises(KeyError):
-        level_db.get(b'1')

--- a/tests/json-fixtures/test_blockchain.py
+++ b/tests/json-fixtures/test_blockchain.py
@@ -114,8 +114,8 @@ def test_blockchain_fixtures(fixture_name, fixture):
     # TODO: find out if this is supposed to pass?
     # if 'genesisRLP' in fixture:
     #     assert rlp.encode(genesis_header) == fixture['genesisRLP']
-
     db = get_db_backend()
+
     chain = MainnetChain
     # TODO: It would be great if we can figure out an API for re-configuring
     # start block numbers that was more elegant.

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{27,34,35}-{core,p2p,leveldb,state-all,state-fast,state-slow,blockchain-fast,blockchain-slow,transactions,vm-all,vm-fast,vm-limits,vm-performance}
+    py{27,34,35}-{core,p2p,database,state-all,state-fast,state-slow,blockchain-fast,blockchain-slow,transactions,vm-all,vm-fast,vm-limits,vm-performance}
     flake8
 
 [flake8]
@@ -17,7 +17,7 @@ commands=
     blockchain-slow: py.test {posargs:tests/json-fixtures/test_blockchain.py -m blockchain_slow}
     core: py.test {posargs:tests/core}
     p2p: py.test {posargs:evm/p2p}
-    leveldb: py.test {posargs:tests/level-db}
+    database: py.test {posargs:tests/database}
     state-all: py.test {posargs:tests/json-fixtures/test_state.py}
     state-fast: py.test {posargs:tests/json-fixtures/test_state.py -m "not state_slow"}
     state-slow: py.test {posargs:tests/json-fixtures/test_state.py -m state_slow}
@@ -29,7 +29,7 @@ commands=
 deps =
     -r{toxinidir}/requirements-dev.txt
     coincurve: coincurve
-    leveldb: leveldb
+    database: leveldb
 basepython =
     py27: python2.7
     py34: python3.4

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ commands=
     vm-performance: py.test {posargs:tests/json-fixtures/test_virtual_machine.py -m vm_performance}
 deps =
     -r{toxinidir}/requirements-dev.txt
-    coincurve: coincurve
+    coincurve
     database: leveldb
 basepython =
     py27: python2.7


### PR DESCRIPTION
### What was wrong?

The existing snapshot and revert functionality wasn't going to scale with real blockchain data sizes.

### How was it fixed?

* Remove the snapshot functionality from the database backends
* Implemented a wrapper that journals the underlying db for the state db.

#### Cute Animal Picture

![6a00e54ef9645388340134867cb589970c-800wi](https://user-images.githubusercontent.com/824194/30766888-65fc7166-9fb5-11e7-97de-846981d7ab36.jpg)
