### PR TITLE
better validation error messages

### DIFF
--- a/evm/chain.py
+++ b/evm/chain.py
@@ -160,14 +160,14 @@ class Chain(object):
         Raises BlockNotFound if there's no block with the given number in the
         canonical chain.
         """
-        validate_uint256(block_number)
+        validate_uint256(block_number, title="Block Number")
         return self.get_block_by_hash(lookup_block_hash(self.db, block_number))
 
     def get_block_by_hash(self, block_hash):
         """
         Returns the requested block as specified by block hash.
         """
-        validate_word(block_hash)
+        validate_word(block_hash, title="Block Hash")
         block_header = self.get_block_header_by_hash(block_hash)
         vm = self.get_vm(block_header)
         return vm.get_block_by_header(block_header)

--- a/evm/consensus/pow.py
+++ b/evm/consensus/pow.py
@@ -45,9 +45,9 @@ def get_cache(block_number):
 
 
 def check_pow(block_number, mining_hash, mix_hash, nonce, difficulty):
-    validate_length(mix_hash, 32)
-    validate_length(mining_hash, 32)
-    validate_length(nonce, 8)
+    validate_length(mix_hash, 32, title="Mix Hash")
+    validate_length(mining_hash, 32, title="Mining Hash")
+    validate_length(nonce, 8, title="POW Nonce")
     cache = get_cache(block_number)
     mining_output = hashimoto_light(
         block_number, cache, mining_hash, big_endian_to_int(nonce))
@@ -55,4 +55,4 @@ def check_pow(block_number, mining_hash, mix_hash, nonce, difficulty):
         raise ValidationError("mix hash mismatch; {0} != {1}".format(
             encode_hex(mining_output[b'mix digest']), encode_hex(mix_hash)))
     result = big_endian_to_int(mining_output[b'result'])
-    validate_lte(result, 2**256 // difficulty)
+    validate_lte(result, 2**256 // difficulty, title="POW Difficulty")

--- a/evm/precompile.py
+++ b/evm/precompile.py
@@ -57,10 +57,10 @@ def precompile_ecrecover(computation):
     s = big_endian_to_int(s_bytes)
 
     try:
-        validate_lt_secpk1n(r)
-        validate_lt_secpk1n(s)
-        validate_lte(v, 28)
-        validate_gte(v, 27)
+        validate_lt_secpk1n(r, title="ECRecover: R")
+        validate_lt_secpk1n(s, title="ECRecover: S")
+        validate_lte(v, 28, title="ECRecover: V")
+        validate_gte(v, 27, title="ECRecover: V")
     except ValidationError:
         return computation
 

--- a/evm/state.py
+++ b/evm/state.py
@@ -82,9 +82,9 @@ class State(object):
         return self._trie.root_hash
 
     def set_storage(self, address, slot, value):
-        validate_uint256(value)
-        validate_uint256(slot)
-        validate_canonical_address(address)
+        validate_uint256(value, title="Storage Value")
+        validate_uint256(slot, title="Storage Slot")
+        validate_canonical_address(address, title="Storage Address")
 
         account = self._get_account(address)
         storage = HashTrie(Trie(self.db, account.storage_root))
@@ -101,8 +101,8 @@ class State(object):
         self._set_account(address, account)
 
     def get_storage(self, address, slot):
-        validate_canonical_address(address)
-        validate_uint256(slot)
+        validate_canonical_address(address, title="Storage Address")
+        validate_uint256(slot, title="Storage Slot")
 
         account = self._get_account(address)
         storage = HashTrie(Trie(self.db, account.storage_root))
@@ -116,15 +116,15 @@ class State(object):
             return 0
 
     def delete_storage(self, address):
-        validate_canonical_address(address)
+        validate_canonical_address(address, title="Storage Address")
 
         account = self._get_account(address)
         account.storage_root = BLANK_ROOT_HASH
         self._set_account(address, account)
 
     def set_balance(self, address, balance):
-        validate_canonical_address(address)
-        validate_uint256(balance)
+        validate_canonical_address(address, title="Storage Address")
+        validate_uint256(balance, title="Account Balance")
 
         account = self._get_account(address)
         account.balance = balance
@@ -135,14 +135,14 @@ class State(object):
         self.set_balance(address, self.get_balance(address) + delta)
 
     def get_balance(self, address):
-        validate_canonical_address(address)
+        validate_canonical_address(address, title="Storage Address")
 
         account = self._get_account(address)
         return account.balance
 
     def set_nonce(self, address, nonce):
-        validate_canonical_address(address)
-        validate_uint256(nonce)
+        validate_canonical_address(address, title="Storage Address")
+        validate_uint256(nonce, title="Nonce")
 
         account = self._get_account(address)
         account.nonce = nonce
@@ -150,14 +150,14 @@ class State(object):
         self._set_account(address, account)
 
     def get_nonce(self, address):
-        validate_canonical_address(address)
+        validate_canonical_address(address, title="Storage Address")
 
         account = self._get_account(address)
         return account.nonce
 
     def set_code(self, address, code):
-        validate_canonical_address(address)
-        validate_is_bytes(code)
+        validate_canonical_address(address, title="Storage Address")
+        validate_is_bytes(code, title="Code")
 
         account = self._get_account(address)
 
@@ -166,7 +166,7 @@ class State(object):
         self._set_account(address, account)
 
     def get_code(self, address):
-        validate_canonical_address(address)
+        validate_canonical_address(address, title="Storage Address")
         account = self._get_account(address)
         try:
             return self.db[account.code_hash]
@@ -174,7 +174,7 @@ class State(object):
             return b''
 
     def delete_code(self, address):
-        validate_canonical_address(address)
+        validate_canonical_address(address, title="Storage Address")
         account = self._get_account(address)
         del self.db[account.code_hash]
         account.code_hash = EMPTY_SHA3
@@ -187,7 +187,7 @@ class State(object):
         del self._trie[address]
 
     def account_exists(self, address):
-        validate_canonical_address(address)
+        validate_canonical_address(address, title="Storage Address")
         return bool(self._trie[address])
 
     def touch_account(self, address):

--- a/evm/utils/blocks.py
+++ b/evm/utils/blocks.py
@@ -84,7 +84,7 @@ def get_block_header_by_hash(db, block_hash):
 
     Raises BlockNotFound if it is not present in the db.
     """
-    validate_word(block_hash)
+    validate_word(block_hash, title="Block Hash")
     try:
         block = db.get(block_hash)
     except KeyError:
@@ -97,7 +97,7 @@ def lookup_block_hash(db, block_number):
     """
     Return the block hash for the given block number.
     """
-    validate_uint256(block_number)
+    validate_uint256(block_number, title="Block Number")
     number_to_hash_key = make_block_number_to_hash_lookup_key(block_number)
     # TODO: can raise KeyError
     block_hash = rlp.decode(

--- a/evm/validation.py
+++ b/evm/validation.py
@@ -21,104 +21,145 @@ from evm.exceptions import (
 )
 
 
-def validate_is_bytes(value):
+def validate_is_bytes(value, title="Value"):
     if not isinstance(value, bytes):
-        raise ValidationError("Value must be a byte string.  Got: {0}".format(type(value)))
+        raise ValidationError(
+            "{title} must be a byte string.  Got: {0}".format(type(value), title=title)
+        )
 
 
-def validate_is_integer(value):
+def validate_is_integer(value, title="Value"):
     if not isinstance(value, int) or isinstance(value, bool):
-        raise ValidationError("Value must be a an integer.  Got: {0}".format(type(value)))
+        raise ValidationError(
+            "{title} must be a an integer.  Got: {0}".format(type(value), title=title)
+        )
 
 
-def validate_length(value, length):
+def validate_length(value, length, title="Value"):
     if not len(value) == length:
         raise ValidationError(
-            "Value must be of length {0}.  Got {1} of length {2}".format(
+            "{title} must be of length {0}.  Got {1} of length {2}".format(
                 length,
                 value,
                 len(value),
+                title=title,
             )
         )
 
 
-def validate_length_lte(value, maximum_length):
+def validate_length_lte(value, maximum_length, title="Value"):
     if len(value) > maximum_length:
         raise ValidationError(
-            "Value must be of length less than or equal to {0}.  "
+            "{title} must be of length less than or equal to {0}.  "
             "Got {1} of length {2}".format(
                 maximum_length,
                 value,
                 len(value),
+                title=title,
             )
         )
 
 
-def validate_gte(value, minimum):
+def validate_gte(value, minimum, title="Value"):
     if value < minimum:
         raise ValidationError(
-            "Value {0} is not greater than or equal to {1}".format(
-                value, minimum,
+            "{title} {0} is not greater than or equal to {1}".format(
+                value,
+                minimum,
+                title=title,
             )
         )
     validate_is_integer(value)
 
 
-def validate_gt(value, minimum):
+def validate_gt(value, minimum, title="Value"):
     if value <= minimum:
-        raise ValidationError("Value {0} is not greater than {1}".format(value, minimum))
-    validate_is_integer(value)
+        raise ValidationError(
+            "{title} {0} is not greater than {1}".format(value, minimum, title=title)
+        )
+    validate_is_integer(value, title=title)
 
 
-def validate_lte(value, maximum):
+def validate_lte(value, maximum, title="Value"):
     if value > maximum:
         raise ValidationError(
-            "Value {0} is not less than or equal to {1}".format(
-                value, maximum,
+            "{title} {0} is not less than or equal to {1}".format(
+                value,
+                maximum,
+                title=title,
             )
         )
-    validate_is_integer(value)
+    validate_is_integer(value, title=title)
 
 
-def validate_lt(value, maximum):
+def validate_lt(value, maximum, title="Value"):
     if value >= maximum:
-        raise ValidationError("Value {0} is not less than {1}".format(value, maximum))
-    validate_is_integer(value)
+        raise ValidationError(
+            "{title} {0} is not less than {1}".format(value, maximum, title=title)
+        )
+    validate_is_integer(value, title=title)
 
 
-def validate_canonical_address(value):
+def validate_canonical_address(value, title="Value"):
     if not isinstance(value, bytes) or not len(value) == 20:
         raise ValidationError(
-            "Value {0} is not a valid canonical address".format(value)
+            "{title} {0} is not a valid canonical address".format(value, title=title)
         )
 
 
-def validate_multiple_of(value, multiple_of):
+def validate_multiple_of(value, multiple_of, title="Value"):
     if not value % multiple_of == 0:
         raise ValidationError(
-            "Value {0} is not a multiple of {1}".format(value, multiple_of)
+            "{title} {0} is not a multiple of {1}".format(value, multiple_of, title=title)
         )
 
 
-def validate_is_boolean(value):
+def validate_is_boolean(value, title="Value"):
     if not isinstance(value, bool):
-        raise ValidationError("Value must be an boolean.  Got type: {0}".format(type(value)))
+        raise ValidationError(
+            "{title} must be an boolean.  Got type: {0}".format(type(value), title=title)
+        )
 
 
-def validate_word(value):
+def validate_word(value, title="Value"):
     if not isinstance(value, bytes):
-        raise ValidationError("Invalid word:  Must be of bytes type")
+        raise ValidationError(
+            "{title} is not a valid word. Must be of bytes type: Got: {0}".format(
+                type(value),
+                title=title,
+            )
+        )
     elif not len(value) == 32:
-        raise ValidationError("Invalid word:  Must be 32 bytes in length")
+        raise ValidationError(
+            "{title} is not a valid word. Must be 32 bytes in length: Got: {0}".format(
+                len(value),
+                title=title,
+            )
+        )
 
 
-def validate_uint256(value):
+def validate_uint256(value, title="Value"):
     if not isinstance(value, int) or isinstance(value, bool):
-        raise ValidationError("Invalid UINT256: Must be an integer")
+        raise ValidationError(
+            "{title} must be an integer: Got: {0}".format(
+                type(value),
+                title=title,
+            )
+        )
     if value < 0:
-        raise ValidationError("Invalid UINT256: Value is negative")
+        raise ValidationError(
+            "{title} cannot be negative: Got: {0}".format(
+                value,
+                title=title,
+            )
+        )
     if value > UINT_256_MAX:
-        raise ValidationError("Invalid UINT256: Value is greater than 2**256 - 1")
+        raise ValidationError(
+            "{title} exeeds maximum UINT256 size.  Got: {0}".format(
+                value,
+                title=title,
+            )
+        )
 
 
 def validate_stack_item(value):
@@ -126,14 +167,17 @@ def validate_stack_item(value):
         return
     elif isinstance(value, int) and 0 <= value <= UINT_256_MAX:
         return
-    raise ValidationError("Invalid bytes or UINT256")
+    raise ValidationError(
+        "Invalid Stack Item: Must be either a length 32 byte "
+        "string or a 256 bit integer. Got {0}".format(value)
+    )
 
 
 validate_lt_secpk1n = functools.partial(validate_lte, maximum=SECPK1_N - 1)
 validate_lt_secpk1n2 = functools.partial(validate_lte, maximum=SECPK1_N // 2 - 1)
 
 
-def validate_unique(values):
+def validate_unique(values, title="Value"):
     if not isdistinct(values):
         duplicates = pipe(
             values,
@@ -143,19 +187,20 @@ def validate_unique(values):
             tuple,  # cast them to an immutiable form
         )
         raise ValidationError(
-            "The values provided are not unique.  Duplicates: {0}".format(
-                ', '.join((str(value) for value in duplicates))
+            "{title} does not contain unique items.  Duplicates: {0}".format(
+                ', '.join((str(value) for value in duplicates)),
+                title=title,
             )
         )
 
 
-def validate_block_number(block_number):
-    validate_is_integer(block_number)
-    validate_gte(block_number, 0)
+def validate_block_number(block_number, title="Block Number"):
+    validate_is_integer(block_number, title="Block Number")
+    validate_gte(block_number, 0, title="Block Number")
 
 
 def validate_vm_block_numbers(vm_block_numbers):
-    validate_unique(vm_block_numbers)
+    validate_unique(vm_block_numbers, title="Block Number set")
 
     for block_number in vm_block_numbers:
         validate_block_number(block_number)

--- a/evm/vm/code_stream.py
+++ b/evm/vm/code_stream.py
@@ -15,7 +15,7 @@ class CodeStream(object):
     logger = logging.getLogger('evm.vm.CodeStream')
 
     def __init__(self, code_bytes):
-        validate_is_bytes(code_bytes)
+        validate_is_bytes(code_bytes, title="CodeStream bytes")
         self.stream = io.BytesIO(code_bytes)
         self.invalid_positions = set()
         self.depth_processed = 0

--- a/evm/vm/computation.py
+++ b/evm/vm/computation.py
@@ -124,8 +124,8 @@ class Computation(object):
     # Memory Management
     #
     def extend_memory(self, start_position, size):
-        validate_uint256(start_position)
-        validate_uint256(size)
+        validate_uint256(start_position, title="Memory start position")
+        validate_uint256(size, title="Memory size")
 
         before_size = ceil32(len(self.memory))
         after_size = ceil32(start_position + size)
@@ -172,7 +172,7 @@ class Computation(object):
         self._output = value
 
     def register_account_for_deletion(self, beneficiary):
-        validate_canonical_address(beneficiary)
+        validate_canonical_address(beneficiary, title="Suicide beneficiary address")
 
         if self.msg.storage_address in self.accounts_to_delete:
             raise ValueError(
@@ -191,10 +191,10 @@ class Computation(object):
             )).items())
 
     def add_log_entry(self, account, topics, data):
-        validate_canonical_address(account)
+        validate_canonical_address(account, title="Log entry address")
         for topic in topics:
-            validate_uint256(topic)
-        validate_is_bytes(data)
+            validate_uint256(topic, title="Log entry topic")
+        validate_is_bytes(data, title="Log entry data")
         self.log_entries.append((account, topics, data))
 
     #

--- a/evm/vm/flavors/frontier/blocks.py
+++ b/evm/vm/flavors/frontier/blocks.py
@@ -101,7 +101,7 @@ class FrontierBlock(BaseBlock):
             parent_header = self.get_parent_header()
 
             self.validate_gas_limit()
-            validate_length_lte(self.header.extra_data, 32)
+            validate_length_lte(self.header.extra_data, 32, title="BlockHeader.extra_data")
 
             # timestamp
             if self.header.timestamp < parent_header.timestamp:

--- a/evm/vm/flavors/frontier/headers.py
+++ b/evm/vm/flavors/frontier/headers.py
@@ -21,7 +21,7 @@ def compute_frontier_difficulty(parent_header, timestamp):
     """
     Computes the difficulty for a frontier block based on the parent block.
     """
-    validate_gt(timestamp, parent_header.timestamp)
+    validate_gt(timestamp, parent_header.timestamp, title="Header timestamp")
 
     offset = parent_header.difficulty // DIFFICULTY_ADJUSTMENT_DENOMINATOR
 

--- a/evm/vm/flavors/frontier/transactions.py
+++ b/evm/vm/flavors/frontier/transactions.py
@@ -48,25 +48,25 @@ class FrontierTransaction(BaseTransaction):
     ]
 
     def validate(self):
-        validate_uint256(self.nonce)
-        validate_uint256(self.gas_price)
-        validate_uint256(self.gas)
+        validate_uint256(self.nonce, title="Transaction.nonce")
+        validate_uint256(self.gas_price, title="Transaction.gas_price")
+        validate_uint256(self.gas, title="Transaction.gas")
         if self.to != CREATE_CONTRACT_ADDRESS:
-            validate_canonical_address(self.to)
-        validate_uint256(self.value)
-        validate_is_bytes(self.data)
+            validate_canonical_address(self.to, title="Transaction.to")
+        validate_uint256(self.value, title="Transaction.value")
+        validate_is_bytes(self.data, title="Transaction.data")
 
-        validate_uint256(self.v)
-        validate_uint256(self.r)
-        validate_uint256(self.s)
+        validate_uint256(self.v, title="Transaction.v")
+        validate_uint256(self.r, title="Transaction.r")
+        validate_uint256(self.s, title="Transaction.s")
 
-        validate_lt_secpk1n(self.r)
-        validate_gte(self.r, minimum=1)
-        validate_lt_secpk1n(self.s)
-        validate_gte(self.s, minimum=1)
+        validate_lt_secpk1n(self.r, title="Transaction.r")
+        validate_gte(self.r, minimum=1, title="Transaction.r")
+        validate_lt_secpk1n(self.s, title="Transaction.s")
+        validate_gte(self.s, minimum=1, title="Transaction.s")
 
-        validate_gte(self.v, minimum=27)
-        validate_lte(self.v, maximum=28)
+        validate_gte(self.v, minimum=27, title="Transaction.v")
+        validate_lte(self.v, maximum=28, title="Transaction.v")
 
         super(FrontierTransaction, self).validate()
 
@@ -105,13 +105,13 @@ class FrontierUnsignedTransaction(BaseUnsignedTransaction):
     ]
 
     def validate(self):
-        validate_uint256(self.nonce)
-        validate_is_integer(self.gas_price)
-        validate_uint256(self.gas)
+        validate_uint256(self.nonce, title="Transaction.nonce")
+        validate_is_integer(self.gas_price, title="Transaction.gas_price")
+        validate_uint256(self.gas, title="Transaction.gas")
         if self.to != CREATE_CONTRACT_ADDRESS:
-            validate_canonical_address(self.to)
-        validate_uint256(self.value)
-        validate_is_bytes(self.data)
+            validate_canonical_address(self.to, title="Transaction.to")
+        validate_uint256(self.value, title="Transaction.value")
+        validate_is_bytes(self.data, title="Transaction.data")
         super(FrontierUnsignedTransaction, self).validate()
 
     def as_signed_transaction(self, private_key):

--- a/evm/vm/flavors/homestead/headers.py
+++ b/evm/vm/flavors/homestead/headers.py
@@ -24,7 +24,7 @@ def compute_homestead_difficulty(parent_header, timestamp):
     Computes the difficulty for a homestead block based on the parent block.
     """
     parent_tstamp = parent_header.timestamp
-    validate_gt(timestamp, parent_tstamp)
+    validate_gt(timestamp, parent_tstamp, title="Header.timestamp")
     offset = parent_header.difficulty // DIFFICULTY_ADJUSTMENT_DENOMINATOR
     sign = max(
         1 - (timestamp - parent_tstamp) // HOMESTEAD_DIFF_ADJUSTMENT_CUTOFF,

--- a/evm/vm/flavors/homestead/transactions.py
+++ b/evm/vm/flavors/homestead/transactions.py
@@ -22,7 +22,7 @@ from evm.utils.transactions import (
 class HomesteadTransaction(FrontierTransaction):
     def validate(self):
         super(HomesteadTransaction, self).validate()
-        validate_lt_secpk1n2(self.s)
+        validate_lt_secpk1n2(self.s, title="Transaction.s")
 
     def get_intrensic_gas(self):
         return _get_homestead_intrensic_gas(self)

--- a/evm/vm/gas_meter.py
+++ b/evm/vm/gas_meter.py
@@ -18,7 +18,7 @@ class GasMeter(object):
     logger = logging.getLogger('evm.gas.GasMeter')
 
     def __init__(self, start_gas):
-        validate_uint256(start_gas)
+        validate_uint256(start_gas, title="Start Gas")
 
         self.start_gas = start_gas
 

--- a/evm/vm/message.py
+++ b/evm/vm/message.py
@@ -49,45 +49,45 @@ class Message(object):
                  create_address=None,
                  code_address=None,
                  should_transfer_value=True):
-        validate_uint256(gas)
+        validate_uint256(gas, title="Message.gas")
         self.gas = gas
 
-        validate_uint256(gas_price)
+        validate_uint256(gas_price, title="Message.gas_price")
         self.gas_price = gas_price
 
         if to != CREATE_CONTRACT_ADDRESS:
-            validate_canonical_address(to)
+            validate_canonical_address(to, title="Message.to")
         self.to = to
 
-        validate_canonical_address(sender)
+        validate_canonical_address(sender, title="Message.sender")
         self.sender = sender
 
-        validate_uint256(value)
+        validate_uint256(value, title="Message.value")
         self.value = value
 
-        validate_is_bytes(data)
+        validate_is_bytes(data, title="Message.data")
         self.data = data
 
         if origin is not None:
-            validate_canonical_address(origin)
+            validate_canonical_address(origin, title="Message.origin")
         self.origin = origin
 
-        validate_is_integer(depth)
-        validate_gte(depth, minimum=0)
+        validate_is_integer(depth, title="Message.depth")
+        validate_gte(depth, minimum=0, title="Message.depth")
         self.depth = depth
 
-        validate_is_bytes(code)
+        validate_is_bytes(code, title="Message.code")
         self.code = code
 
         if create_address is not None:
-            validate_canonical_address(create_address)
+            validate_canonical_address(create_address, title="Message.storage_address")
         self.storage_address = create_address
 
         if code_address is not None:
-            validate_canonical_address(code_address)
+            validate_canonical_address(code_address, title="Message.code_address")
         self.code_address = code_address
 
-        validate_is_boolean(should_transfer_value)
+        validate_is_boolean(should_transfer_value, title="Message.should_transfer_value")
         self.should_transfer_value = should_transfer_value
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "ethereum-utils>=0.2.0",
         "pyethash>=0.1.27",
         "rlp==0.4.7",
-        "trie>=0.2.4",
+        "trie==0.2.4",
     ],
     extra_require={
         'coincurve': [


### PR DESCRIPTION
### What was wrong?

When a validation error occurred, it would often have a cryptic message such as:

> "Value 28 is not less than or equal to 0"

It was really difficult to divine where this message originated from and what it was validating.

### How was it fixed?

All of the `validate_x` functions now accept an optional `title` parameter.  When provided, the corresponding message would then look something like this

```python
validate_lte(..., title="Block Number")
```

> "Block Number 28 is not less than or equal to 0"



#### Cute Animal Picture

![baby-pig-1](https://user-images.githubusercontent.com/824194/30766313-4dbb1796-9fb1-11e7-9550-eafa5e7fd795.jpg)
