### PR TITLE
Piper/add chain.mine block api

### DIFF
--- a/evm/chain.py
+++ b/evm/chain.py
@@ -236,7 +236,7 @@ class Chain(object):
                 )
             )
 
-        parent_chain = self.get_parent_chain(block)
+        parent_chain = self.get_chain_at_block_parent(block)
         imported_block = parent_chain.get_vm().import_block(block)
 
         # Validate the imported block.
@@ -252,7 +252,7 @@ class Chain(object):
 
     def mine_block(self, *args, **kwargs):
         """
-        TODO: fill this in.
+        Mines the current block.
         """
         mined_block = self.get_vm().mine_block(*args, **kwargs)
 
@@ -264,9 +264,9 @@ class Chain(object):
 
         return mined_block
 
-    def get_parent_chain(self, block):
+    def get_chain_at_block_parent(self, block):
         """
-        TODO: fill this in.
+        Returns a `Chain` instance with this block's parent at the chain head.
         """
         try:
             parent_header = self.get_block_header_by_hash(block.header.parent_hash)

--- a/evm/chain.py
+++ b/evm/chain.py
@@ -249,6 +249,16 @@ class Chain(object):
 
         return imported_block
 
+    def mine_block(self, *args, **kwargs):
+        mined_block = self.get_vm().mine_block(*args, **kwargs)
+
+        self.validate_block(mined_block)
+
+        persist_block_to_db(self.db, mined_block)
+        if self.should_be_canonical_chain_head(mined_block):
+            self.add_to_canonical_chain_head(mined_block)
+        return mined_block
+
     def ensure_blocks_are_equal(self, block1, block2):
         if block1 == block2:
             return

--- a/evm/validation.py
+++ b/evm/validation.py
@@ -204,3 +204,26 @@ def validate_vm_block_numbers(vm_block_numbers):
 
     for block_number in vm_block_numbers:
         validate_block_number(block_number)
+
+
+ALLOWED_HEADER_FIELDS = {
+    'coinbase',
+    'gas_limit',
+    'timestamp',
+    'extra_data',
+    'mix_hash',
+    'nonce',
+    'uncle_hash',
+}
+
+
+def validate_header_parames_for_configuration(header_params):
+    extra_fields = set(header_params.keys()).difference(ALLOWED_HEADER_FIELDS)
+    if extra_fields:
+        raise ValidationError(
+            "The `configure_header` method may only be used with the fields ({0}). "
+            "The provided fields ({1}) are not supported".format(
+                ", ".join(tuple(sorted(ALLOWED_HEADER_FIELDS))),
+                ", ".join(tuple(sorted(extra_fields))),
+            )
+        )

--- a/evm/validation.py
+++ b/evm/validation.py
@@ -217,7 +217,7 @@ ALLOWED_HEADER_FIELDS = {
 }
 
 
-def validate_header_parames_for_configuration(header_params):
+def validate_header_params_for_configuration(header_params):
     extra_fields = set(header_params.keys()).difference(ALLOWED_HEADER_FIELDS)
     if extra_fields:
         raise ValidationError(

--- a/evm/validation.py
+++ b/evm/validation.py
@@ -213,7 +213,7 @@ ALLOWED_HEADER_FIELDS = {
     'extra_data',
     'mix_hash',
     'nonce',
-    'uncle_hash',
+    'uncles_hash',
 }
 
 

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import rlp
+
 from contextlib import contextmanager
 import logging
 
@@ -20,6 +22,9 @@ from evm.logic.invalid import (
 
 from evm.utils.blocks import (
     get_block_header_by_hash,
+)
+from evm.utils.keccak import (
+    keccak,
 )
 
 
@@ -133,15 +138,15 @@ class VM(object):
             extra_data=block.header.extra_data,
             mix_hash=block.header.mix_hash,
             nonce=block.header.nonce,
+            uncles_hash=keccak(rlp.encode(block.uncles)),
         )
 
+        # run all of the transactions.
         for transaction in block.transactions:
             self.apply_transaction(transaction)
 
-        # TODO: this is weird and should probably be done by just setting the
-        # uncleshash on the header in the call to `configure_header` above.
-        for uncle in block.uncles:
-            self.block.add_uncle(uncle)
+        # transfer the list of uncles.
+        self.block.uncles = block.uncles
 
         return self.mine_block()
 

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -138,6 +138,8 @@ class VM(object):
         for transaction in block.transactions:
             self.apply_transaction(transaction)
 
+        # TODO: this is weird and should probably be done by just setting the
+        # uncleshash on the header in the call to `configure_header` above.
         for uncle in block.uncles:
             self.block.add_uncle(uncle)
 
@@ -177,6 +179,10 @@ class VM(object):
                 )
 
         return block
+
+    def validate_block(self, block, chain):
+        """
+        """
 
     #
     # Transactions

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -185,10 +185,6 @@ class VM(object):
 
         return block
 
-    def validate_block(self, block, chain):
-        """
-        """
-
     #
     # Transactions
     #

--- a/evm/vm/flavors/frontier/headers.py
+++ b/evm/vm/flavors/frontier/headers.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from evm.validation import (
     validate_gt,
+    validate_header_parames_for_configuration,
 )
 from evm.constants import (
     GENESIS_GAS_LIMIT,
@@ -77,26 +78,8 @@ def create_frontier_header_from_parent(parent_header, **header_params):
     return header
 
 
-ALLOWED_HEADER_FIELDS = {
-    'coinbase',
-    'gas_limit',
-    'timestamp',
-    'extra_data',
-    'mix_hash',
-    'nonce',
-}
-
-
 def configure_frontier_header(vm, **header_params):
-    extra_fields = set(header_params.keys()).difference(ALLOWED_HEADER_FIELDS)
-    if extra_fields:
-        raise ValueError(
-            "The `configure_header` method may only be used with the fields ({0}). "
-            "The provided fields ({1}) are not supported".format(
-                ", ".join(tuple(sorted(ALLOWED_HEADER_FIELDS))),
-                ", ".join(tuple(sorted(extra_fields))),
-            )
-        )
+    validate_header_parames_for_configuration(header_params)
 
     for field_name, value in header_params.items():
         setattr(vm.block.header, field_name, value)

--- a/evm/vm/flavors/frontier/headers.py
+++ b/evm/vm/flavors/frontier/headers.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from evm.validation import (
     validate_gt,
-    validate_header_parames_for_configuration,
+    validate_header_params_for_configuration,
 )
 from evm.constants import (
     GENESIS_GAS_LIMIT,
@@ -79,7 +79,7 @@ def create_frontier_header_from_parent(parent_header, **header_params):
 
 
 def configure_frontier_header(vm, **header_params):
-    validate_header_parames_for_configuration(header_params)
+    validate_header_params_for_configuration(header_params)
 
     for field_name, value in header_params.items():
         setattr(vm.block.header, field_name, value)

--- a/evm/vm/flavors/homestead/headers.py
+++ b/evm/vm/flavors/homestead/headers.py
@@ -4,7 +4,7 @@ from eth_utils import (
 
 from evm.validation import (
     validate_gt,
-    validate_header_parames_for_configuration,
+    validate_header_params_for_configuration,
 )
 from evm.constants import (
     DIFFICULTY_ADJUSTMENT_DENOMINATOR,
@@ -54,7 +54,7 @@ def create_homestead_header_from_parent(parent_header, **header_params):
 
 
 def configure_homestead_header(vm, **header_params):
-    validate_header_parames_for_configuration(header_params)
+    validate_header_params_for_configuration(header_params)
 
     for field_name, value in header_params.items():
         setattr(vm.block.header, field_name, value)

--- a/tests/core/fixtures.py
+++ b/tests/core/fixtures.py
@@ -10,14 +10,8 @@ from eth_keys import KeyAPI
 from evm import Chain
 from evm import constants
 from evm.db import get_db_backend
-from evm.exceptions import (
-    ValidationError,
-)
 from evm.vm.flavors.frontier import FrontierVM
 
-from evm.utils.blocks import (
-    persist_block_to_db,
-)
 
 
 @pytest.fixture
@@ -84,26 +78,7 @@ valid_block_rlp = decode_hex(
 
 
 def import_block_without_validation(chain, block):
-    """
-    A copy of `Chain.import_block` without the block validation.
-    """
-    if block.number > chain.header.block_number:
-        raise ValidationError(
-            "Attempt to import block #{0}.  Cannot import block with number "
-            "greater than current block #{1}.".format(
-                block.number,
-                chain.header.block_number,
-            )
-        )
-
-    parent_chain = chain.get_parent_chain(block)
-    imported_block = parent_chain.get_vm().import_block(block)
-
-    persist_block_to_db(chain.db, imported_block)
-    if chain.should_be_canonical_chain_head(imported_block):
-        chain.add_to_canonical_chain_head(imported_block)
-
-    return imported_block
+    return Chain.import_block(chain, block, perform_validation=False)
 
 
 @pytest.fixture

--- a/tests/core/fixtures.py
+++ b/tests/core/fixtures.py
@@ -13,7 +13,6 @@ from evm.db import get_db_backend
 from evm.vm.flavors.frontier import FrontierVM
 
 
-
 @pytest.fixture
 def chain():
     """

--- a/tests/core/fixtures.py
+++ b/tests/core/fixtures.py
@@ -10,7 +10,14 @@ from eth_keys import KeyAPI
 from evm import Chain
 from evm import constants
 from evm.db import get_db_backend
+from evm.exceptions import (
+    ValidationError,
+)
 from evm.vm.flavors.frontier import FrontierVM
+
+from evm.utils.blocks import (
+    persist_block_to_db,
+)
 
 
 @pytest.fixture

--- a/tests/core/fixtures.py
+++ b/tests/core/fixtures.py
@@ -76,6 +76,29 @@ valid_block_rlp = decode_hex(
     "0xf90260f901f9a07285abd5b24742f184ad676e31f6054663b3529bc35ea2fcad8a3e0f642a46f7a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347948888f1f195afa192cfee860698584c030f4c9db1a0964e6c9995e7e3757e934391b4f16b50c20409ee4eb9abd4c4617cb805449b9aa053d5b71a8fbb9590de82d69dfa4ac31923b0c8afce0d30d0d8d1e931f25030dca0bc37d79753ad738a6dac4921e57392f145d8887476de3f783dfa7edae9283e52b90100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008302000001832fefd8825208845754132380a0194605bacef646779359318c7b5899559a5bf4074bbe2cfb7e1b83b1504182dd88e0205813b22e5a9cf861f85f800a82c35094095e7baea6a6c7c4c2dfeb977efac326af552d870a801ba0f3266921c93d600c43f6fa4724b7abae079b35b9e95df592f95f9f3445e94c88a012f977552ebdb7a492cf35f3106df16ccb4576ebad4113056ee1f52cbe4978c1c0")  # noqa: E501
 
 
+def import_block_without_validation(chain, block):
+    """
+    A copy of `Chain.import_block` without the block validation.
+    """
+    if block.number > chain.header.block_number:
+        raise ValidationError(
+            "Attempt to import block #{0}.  Cannot import block with number "
+            "greater than current block #{1}.".format(
+                block.number,
+                chain.header.block_number,
+            )
+        )
+
+    parent_chain = chain.get_parent_chain(block)
+    imported_block = parent_chain.get_vm().import_block(block)
+
+    persist_block_to_db(chain.db, imported_block)
+    if chain.should_be_canonical_chain_head(imported_block):
+        chain.add_to_canonical_chain_head(imported_block)
+
+    return imported_block
+
+
 @pytest.fixture
 def chain_without_block_validation():
     """
@@ -88,7 +111,7 @@ def chain_without_block_validation():
     """
     # Disable block validation so that we don't need to construct finalized blocks.
     overrides = {
-        'ensure_blocks_are_equal': lambda self, b1, b2: None,
+        'import_block': import_block_without_validation,
         'validate_block': lambda self, block: None,
     }
     klass = Chain.configure(

--- a/tests/core/vm/test_vm.py
+++ b/tests/core/vm/test_vm.py
@@ -45,7 +45,7 @@ def test_import_block(chain_without_block_validation):  # noqa: F811
     tx = new_transaction(vm, from_, recipient, amount, chain.funded_address_private_key)
     computation = vm.apply_transaction(tx)
     assert computation.error is None
-    parent_vm = chain.get_parent_chain(vm.block).get_vm()
+    parent_vm = chain.get_chain_at_block_parent(vm.block).get_vm()
     block = parent_vm.import_block(vm.block)
     assert block.transactions == [tx]
 


### PR DESCRIPTION
### What was wrong?

* The `Chain.ensure_blocks_are_equal` seemed to only exist because it needed to be overridden in some tests.
* Needed a `Chain.mine_block()` function for non-import based blockchain advancement.  This is needed in #92 
* The `configure_homestead_header` function delegated to the `configure_frontier_header` function, but only to perform the validation of the `header_params`.

### How was it fixed?

* Modified the test fixture that needed this override and moved this to a utility function.
* Added a `Chain.mine_block()` API
* Moved the `header_params` validation to a stand-alone function and decoupled the two frontier and homestead functions.


#### Cute Animal Picture

> put a cute animal picture here.