### PR TITLE
Implement peer.handshake()

### DIFF
--- a/evm/p2p/auth.py
+++ b/evm/p2p/auth.py
@@ -24,7 +24,6 @@ from evm.p2p.constants import (
     SIGNATURE_LEN,
     SUPPORTED_RLPX_VERSION,
 )
-from evm.p2p.peer import Peer
 from evm.p2p.utils import (
     sxor,
 )
@@ -36,6 +35,8 @@ def handshake(remote, privkey):
 
     The Peer will be configured with the shared secrets established during the handshake.
     """
+    # Local import to avoid circular dependencies.
+    from evm.p2p.peer import Peer
     initiator = HandshakeInitiator(remote, privkey)
     reader, writer = yield from initiator.connect()
     aes_secret, mac_secret, egress_mac, ingress_mac = yield from _handshake(

--- a/evm/p2p/constants.py
+++ b/evm/p2p/constants.py
@@ -31,3 +31,9 @@ HEADER_LEN = 16
 
 # Length of an RLPx header's/frame's MAC
 MAC_LEN = 16
+
+# The amount of seconds a connection can be idle.
+CONN_IDLE_TIMEOUT = 30
+
+# Total time, in seconds, for a complete encryption/P2P handshake, both ways.
+HANDSHAKE_TIMEOUT = 5

--- a/evm/p2p/exceptions.py
+++ b/evm/p2p/exceptions.py
@@ -12,3 +12,11 @@ class PeerDisconnected(Exception):
 
 class UnknownProtocolCommand(Exception):
     pass
+
+
+class UselessPeer(Exception):
+    pass
+
+
+class UnreachablePeer(Exception):
+    pass


### PR DESCRIPTION
Similar to auth.handshake(), but this one performs the P2P handshake and
only returns a peer when there are matching sub-protocols.

Also use a timeout on Peer.read() and an asyncio.Event so that Peer.stop() only
returns when the Peer.start() coroutine exits.