### PR TITLE
Piper/backport transaction signing change

### DIFF
--- a/evm/rlp/transactions.py
+++ b/evm/rlp/transactions.py
@@ -88,9 +88,9 @@ class BaseTransaction(rlp.Serializable):
     #
     # Conversion to and creation of unsigned transactions.
     #
-    def as_unsigned_transaction(self):
+    def get_message_for_signing(self):
         """
-        Return an unsigned version of this transaction.
+        Return the bytestring that should be signed in order to create a signed transactions
         """
         raise NotImplementedError("Must be implemented by subclasses")
 

--- a/evm/utils/numeric.py
+++ b/evm/utils/numeric.py
@@ -1,6 +1,5 @@
 import functools
 import math
-import sys
 
 from evm.constants import (
     UINT_255_MAX,
@@ -8,44 +7,20 @@ from evm.constants import (
 )
 
 
-if sys.version_info.major == 2:
-    import struct
-    import codecs
-    import binascii
+def int_to_big_endian(value):
+    byte_length = math.ceil(value.bit_length() / 8)
+    return (value).to_bytes(byte_length, byteorder='big')
 
-    def int_to_big_endian(value):
-        if value == 0:
-            return b'\x00'
 
-        value_as_hex = (hex(value)[2:]).rstrip('L')
+def big_endian_to_int(value):
+    return int.from_bytes(value, byteorder='big')
 
-        if len(value_as_hex) % 2:
-            return binascii.unhexlify('0' + value_as_hex)
-        else:
-            return binascii.unhexlify(value_as_hex)
 
-    def big_endian_to_int(value):
-        if len(value) == 1:
-            return ord(value)
-        elif len(value) <= 8:
-            return struct.unpack('>Q', value.rjust(8, '\x00'))[0]
-        else:
-            return int(codecs.encode(value, 'hex'), 16)
+def int_to_byte(value):
+    return bytes([value])
 
-    int_to_byte = chr
-    byte_to_int = ord
-else:
-    def int_to_big_endian(value):
-        byte_length = math.ceil(value.bit_length() / 8)
-        return (value).to_bytes(byte_length, byteorder='big')
 
-    def big_endian_to_int(value):
-        return int.from_bytes(value, byteorder='big')
-
-    def int_to_byte(value):
-        return bytes([value])
-
-    byte_to_int = ord
+byte_to_int = ord
 
 
 def ceilXX(value, ceiling):
@@ -79,3 +54,11 @@ def safe_ord(value):
         return value
     else:
         return ord(value)
+
+
+def is_even(value):
+    return value % 2 == 0
+
+
+def is_odd(value):
+    return value % 2 == 1

--- a/evm/vm/forks/frontier/transactions.py
+++ b/evm/vm/forks/frontier/transactions.py
@@ -1,3 +1,4 @@
+import rlp
 from rlp.sedes import (
     big_endian_int,
     binary,
@@ -79,15 +80,15 @@ class FrontierTransaction(BaseTransaction):
     def get_intrensic_gas(self):
         return _get_frontier_intrensic_gas(self.data)
 
-    def as_unsigned_transaction(self):
-        return FrontierUnsignedTransaction(
+    def get_message_for_signing(self):
+        return rlp.encode(FrontierUnsignedTransaction(
             nonce=self.nonce,
             gas_price=self.gas_price,
             gas=self.gas,
             to=self.to,
             value=self.value,
             data=self.data,
-        )
+        ))
 
     @classmethod
     def create_unsigned_transaction(cls, nonce, gas_price, gas, to, value, data):

--- a/evm/vm/forks/homestead/transactions.py
+++ b/evm/vm/forks/homestead/transactions.py
@@ -1,3 +1,5 @@
+import rlp
+
 from evm.constants import (
     GAS_TX,
     GAS_TXCREATE,
@@ -27,15 +29,15 @@ class HomesteadTransaction(FrontierTransaction):
     def get_intrensic_gas(self):
         return _get_homestead_intrensic_gas(self)
 
-    def as_unsigned_transaction(self):
-        return HomesteadUnsignedTransaction(
+    def get_message_for_signing(self):
+        return rlp.encode(HomesteadUnsignedTransaction(
             nonce=self.nonce,
             gas_price=self.gas_price,
             gas=self.gas,
             to=self.to,
             value=self.value,
             data=self.data,
-        )
+        ))
 
     @classmethod
     def create_unsigned_transaction(cls, nonce, gas_price, gas, to, value, data):

--- a/tests/core/transaction-utils/conftest.py
+++ b/tests/core/transaction-utils/conftest.py
@@ -1,0 +1,44 @@
+import pytest
+
+
+# from https://github.com/ethereum/tests/blob/c951a3c105d600ccd8f1c3fc87856b2bcca3df0a/BasicTests/txtest.json  # noqa: E501
+TRANSACTION_FIXTURES = [
+    {
+        "chainId": None,
+        "key": "c85ef7d79691fe79573b1a7064c19c1a9819ebdbd1faaab1a8ec92344438aaf4",
+        "nonce": 0,
+        "gasPrice": 1000000000000,
+        "gas": 10000,
+        "to": "13978aee95f38490e9769c39b2773ed763d9cd5f",
+        "value": 10000000000000000,
+        "data": "",
+        "signed": "f86b8085e8d4a510008227109413978aee95f38490e9769c39b2773ed763d9cd5f872386f26fc10000801ba0eab47c1a49bf2fe5d40e01d313900e19ca485867d462fe06e139e3a536c6d4f4a014a569d327dcda4b29f74f93c0e9729d2f49ad726e703f9cd90dbb0fbf6649f1"  # noqa: E501
+    },
+    {
+        "chainId": None,
+        "key": "c87f65ff3f271bf5dc8643484f66b200109caffe4bf98c4cb393dc35740b28c0",
+        "nonce": 0,
+        "gasPrice": 1000000000000,
+        "gas": 10000,
+        "to": "",
+        "value": 0,
+        "data": "6025515b525b600a37f260003556601b596020356000355760015b525b54602052f260255860005b525b54602052f2",  # noqa: E501
+        "signed": "f87f8085e8d4a510008227108080af6025515b525b600a37f260003556601b596020356000355760015b525b54602052f260255860005b525b54602052f21ba05afed0244d0da90b67cf8979b0f246432a5112c0d31e8d5eedd2bc17b171c694a0bb1035c834677c2e1185b8dc90ca6d1fa585ab3d7ef23707e1a497a98e752d1b"  # noqa: E501
+    },
+    {
+        "chainId": 1,
+        "key": "0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318",
+        "nonce": 0,
+        "gasPrice": 234567897654321,
+        "gas": 2000000,
+        "to": "0xF0109fC8DF283027b6285cc889F5aA624EaC1F55",
+        "value": 1000000000,
+        "data": "",
+        "signed": "0xf86a8086d55698372431831e848094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca008025a009ebb6ca057a0535d6186462bc0b465b561c94a295bdb0621fc19208ab149a9ca0440ffd775ce91a833ab410777204d5341a6f9fa91216a6f3ee2c051fea6a0428",  # noqa: E501
+    },
+]
+
+
+@pytest.fixture(params=range(len(TRANSACTION_FIXTURES)))
+def txn_fixture(request):
+    return TRANSACTION_FIXTURES[request.param]

--- a/tests/core/transaction-utils/test_transaction_signature_validation.py
+++ b/tests/core/transaction-utils/test_transaction_signature_validation.py
@@ -1,0 +1,47 @@
+import pytest
+
+import rlp
+
+from eth_utils import (
+    decode_hex,
+    is_same_address,
+)
+
+from eth_keys import keys
+
+from evm.vm.forks.frontier.transactions import (
+    FrontierTransaction,
+)
+from evm.vm.forks.homestead.transactions import (
+    HomesteadTransaction,
+)
+
+from evm.utils.transactions import (
+    extract_transaction_sender,
+    validate_transaction_signature,
+)
+
+
+@pytest.mark.parametrize(
+    "txn_class",
+    (FrontierTransaction, HomesteadTransaction),
+)
+def test_pre_EIP155_transaction_signature_validation(txn_class, txn_fixture):
+    if txn_fixture['chainId'] is not None:
+        pytest.skip("Only testng non-EIP155 transactions")
+    transaction = rlp.decode(decode_hex(txn_fixture['signed']), sedes=txn_class)
+    validate_transaction_signature(transaction)
+    transaction.check_signature_validity()
+
+
+@pytest.mark.parametrize(
+    "txn_class",
+    (FrontierTransaction, HomesteadTransaction),
+)
+def test_pre_EIP155_transaction_sender_extraction(txn_class, txn_fixture):
+    if txn_fixture['chainId'] is not None:
+        pytest.skip("Only testng non-EIP155 transactions")
+    key = keys.PrivateKey(decode_hex(txn_fixture['key']))
+    transaction = rlp.decode(decode_hex(txn_fixture['signed']), sedes=txn_class)
+    sender = extract_transaction_sender(transaction)
+    assert is_same_address(sender, key.public_key.to_canonical_address())

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist=
 
 [flake8]
 max-line-length= 100
-exclude= tests/*
+exclude=
 ignore=
 
 [testenv]


### PR DESCRIPTION
### What was wrong?

Changes transactions api frim `as_unsigned_transaction` to `get_message_for_signing`.

### How was it fixed?

Changed the API on the transaction objects.

#### Cute Animal Picture

> put a cute animal picture here.

