### PR TITLE
Piper/backport statedb mutability fixes

### DIFF
--- a/evm/db/backends/base.py
+++ b/evm/db/backends/base.py
@@ -1,4 +1,4 @@
-class BaseDB(object):
+class BaseDB:
     def get(self, key):
         raise NotImplementedError(
             "The `get` method must be implemented by subclasses of BaseDB"

--- a/evm/db/immutable.py
+++ b/evm/db/immutable.py
@@ -1,0 +1,20 @@
+from evm.db.backends.base import BaseDB
+
+
+class ImmutableDB(BaseDB):
+    _wrapped_db = None
+
+    def __init__(self, wrapped_db):
+        self._wrapped_db = wrapped_db
+
+    def get(self, key):
+        return self._wrapped_db.get(key)
+
+    def set(self, key, value):
+        raise TypeError("Current database is immutable and does not support setting of keys.")
+
+    def exists(self, key):
+        return self._wrapped_db.exists(key)
+
+    def delete(self, key):
+        raise TypeError("Current database is immutable and does not support setting of keys.")

--- a/evm/db/state.py
+++ b/evm/db/state.py
@@ -10,6 +10,9 @@ from evm.constants import (
     BLANK_ROOT_HASH,
     EMPTY_SHA3,
 )
+from evm.db.immutable import (
+    ImmutableDB,
+)
 from evm.rlp.accounts import (
     Account,
 )
@@ -32,7 +35,7 @@ from evm.utils.padding import (
 from .hash_trie import HashTrie
 
 
-class State(object):
+class State:
     """
     High level API around account storage.
     """
@@ -41,9 +44,12 @@ class State(object):
 
     logger = logging.getLogger('evm.state.State')
 
-    def __init__(self, db, root_hash=BLANK_ROOT_HASH):
-        self.db = db
-        self._trie = HashTrie(Trie(db, root_hash))
+    def __init__(self, db, root_hash=BLANK_ROOT_HASH, read_only=False):
+        if read_only:
+            self.db = ImmutableDB(db)
+        else:
+            self.db = db
+        self._trie = HashTrie(Trie(self.db, root_hash))
 
     #
     # Base API

--- a/tests/core/vm/test_vm.py
+++ b/tests/core/vm/test_vm.py
@@ -59,7 +59,7 @@ def test_state_db(chain_without_block_validation):  # noqa: F811
     with vm.state_db() as state_db:
         pass
 
-    with pytest.raises(Exception):  # TODO: fix this to be a real exception
+    with pytest.raises(TypeError):
         state_db.increment_nonce(address)
 
     with vm.state_db(read_only=True) as state_db:

--- a/tests/core/vm/test_vm.py
+++ b/tests/core/vm/test_vm.py
@@ -55,6 +55,13 @@ def test_state_db(chain_without_block_validation):  # noqa: F811
     address = decode_hex('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0c')
     initial_state_root = vm.block.header.state_root
 
+    # test cannot write to state_db after context exits
+    with vm.state_db() as state_db:
+        pass
+
+    with pytest.raises(Exception):  # TODO: fix this to be a real exception
+        state_db.increment_nonce(address)
+
     with vm.state_db(read_only=True) as state_db:
         state_db.get_balance(address)
     assert vm.block.header.state_root == initial_state_root
@@ -63,6 +70,6 @@ def test_state_db(chain_without_block_validation):  # noqa: F811
         state_db.set_balance(address, 10)
     assert vm.block.header.state_root != initial_state_root
 
-    with pytest.raises(AssertionError):
-        with vm.state_db(read_only=True) as state_db:
+    with vm.state_db(read_only=True) as state_db:
+        with pytest.raises(TypeError):
             state_db.set_balance(address, 0)


### PR DESCRIPTION
### What was wrong?

The `vm.state_db` context manager had some pitfalls. 

* it was easy to continue interacting with the state_db after it had left it's context.
* if you were working with a `read_only` statedb, you would not get an error until the context exited.

### How was it fixed?

* Changed the `StateDB` class to have first class support for immutability via a database wrapper.
* Changed the context manager to render the `state_db` object useless once the context has exited.

#### Cute Animal Picture

> put a cute animal picture here.