### PR TITLE
Remove hard coded HALT opcodes in favor of exception pattern

### DIFF
--- a/evm/exceptions.py
+++ b/evm/exceptions.py
@@ -33,6 +33,13 @@ class ValidationError(PyEVMError):
     pass
 
 
+class Halt(PyEVMError):
+    """
+    Raised by opcode function to halt vm execution.
+    """
+    pass
+
+
 class VMError(PyEVMError):
     """
     Class of errors which can be raised during VM execution.

--- a/evm/logic/flow.py
+++ b/evm/logic/flow.py
@@ -2,6 +2,7 @@ from evm import constants
 from evm.exceptions import (
     InvalidJumpDestination,
     InvalidInstruction,
+    Halt,
 )
 from evm.opcode_values import (
     JUMPDEST,
@@ -9,7 +10,7 @@ from evm.opcode_values import (
 
 
 def stop(computation):
-    pass
+    raise Halt('STOP')
 
 
 def jump(computation):

--- a/evm/logic/system.py
+++ b/evm/logic/system.py
@@ -1,5 +1,8 @@
 from evm import constants
 from evm import mnemonics
+from evm.exceptions import (
+    Halt,
+)
 
 from evm.opcode import (
     Opcode,
@@ -22,6 +25,7 @@ def return_op(computation):
 
     output = computation.memory.read(start_position, size)
     computation.output = bytes(output)
+    raise Halt('RETURN')
 
 
 def suicide(computation):
@@ -76,6 +80,7 @@ def _suicide(computation, beneficiary):
 
     # 3rd: Register the account to be deleted
     computation.register_account_for_deletion(beneficiary)
+    raise Halt('SUICIDE')
 
 
 class Create(Opcode):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,9 +10,9 @@ def vm_logger():
 
     handler = logging.StreamHandler(sys.stdout)
 
-    level = logging.TRACE
+    # level = logging.TRACE
     # level = logging.DEBUG
-    # level = logging.INFO
+    level = logging.INFO
 
     logger.setLevel(level)
     handler.setLevel(level)


### PR DESCRIPTION
### What was wrong?

* The `vm.apply_computation` implementation was standard enough that it wasn't being overridden by any of the VM subclasses.
* The opcodes which cause the VM to halt were hard-coded.

### How was it fixed?

* Created a new `Halt` exception that opcodes can raise if they wish to cause VM execution to halt.
* Move the implementation of `apply_computation` into the `BaseVM` class since it doesn't look like it will need to be overwritten.


#### Cute Animal Picture

![daily updated funny birds and animals picdump 1](https://user-images.githubusercontent.com/824194/31786180-d570b632-b4c4-11e7-95da-cf9368352acf.jpg)
