### PR TITLE
Pin flake8 version to 3.5.0

### DIFF
--- a/evm/p2p/discovery.py
+++ b/evm/p2p/discovery.py
@@ -194,8 +194,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         nodes = []
         neighbours = sorted(neighbours)
         for n in neighbours:
-            l = n.address.to_endpoint() + [n.pubkey.to_bytes()]
-            nodes.append(l)
+            nodes.append(n.address.to_endpoint() + [n.pubkey.to_bytes()])
 
         max_neighbours = self._get_max_neighbours_per_packet()
         for i in range(0, len(nodes), max_neighbours):

--- a/evm/vm/code_stream.py
+++ b/evm/vm/code_stream.py
@@ -63,8 +63,6 @@ class CodeStream(object):
         self.pc = pc
         try:
             yield self
-        except:
-            raise
         finally:
             self.pc = anchor_pc
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-flake8==3.3.0
 hypothesis==3.30.0
 pytest-asyncio==0.6.0
 pytest-xdist==1.18.1

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ basepython =
 
 [testenv:flake8]
 basepython=python
-deps=flake8
+deps=flake8==3.5.0
 commands=
     flake8 {toxinidir}/evm
     flake8 {toxinidir}/tests --exclude=""


### PR DESCRIPTION
And fixes a couple issues caught by 3.5.0 that were not caught by the previous version (3.3.0)

Without this we can, all of a sudden, start seeing [failures](https://travis-ci.org/pipermerriam/py-evm/jobs/291541039) when there's a new version of flake8