### PR TITLE
Update canonical chain info whenever we store a header in the DB

### DIFF
--- a/tests/core/chain-object/test_chain.py
+++ b/tests/core/chain-object/test_chain.py
@@ -46,7 +46,8 @@ def test_import_block(chain_without_block_validation):  # noqa: F811
 
 
 def test_canonical_chain(chain):  # noqa: F811
-    genesis_header = chain.get_canonical_block_header_by_number(constants.GENESIS_BLOCK_NUMBER)
+    genesis_header = chain.chaindb.get_canonical_block_header_by_number(
+        constants.GENESIS_BLOCK_NUMBER)
 
     # Our chain fixture is created with only the genesis header, so initially that's the head of
     # the canonical chain.
@@ -55,10 +56,8 @@ def test_canonical_chain(chain):  # noqa: F811
     block = rlp.decode(valid_block_rlp, sedes=FrontierBlock, chaindb=chain.chaindb)
     chain.chaindb.persist_header_to_db(block.header)
 
-    chain.set_as_canonical_chain_head(block.header)
-
     assert chain.get_canonical_head() == block.header
-    canonical_block_1 = chain.get_canonical_block_header_by_number(
+    canonical_block_1 = chain.chaindb.get_canonical_block_header_by_number(
         constants.GENESIS_BLOCK_NUMBER + 1)
     assert canonical_block_1 == block.header
 


### PR DESCRIPTION
The Chain class used to do that, but now it's done as part of BaseChainDB.persist_header_to_db().

I needed this on another branch I'm working on (which changes the LightChain so that it can handle possibly diverging data from multiple peers), but this seemed like a worthwhile refactoring in itself so I'm submitting it separately