### PR TITLE
Change from generator-based to native coroutines

### DIFF
--- a/evm/p2p/discovery.py
+++ b/evm/p2p/discovery.py
@@ -103,14 +103,13 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
     def connection_made(self, transport):
         self.transport = transport
 
-    @asyncio.coroutine
-    def bootstrap(self):
+    async def bootstrap(self):
         while self.transport is None:
             # FIXME: Instead of sleeping here to wait until connection_made() is called to set
             # .transport we should instead only call it after we know it's been set.
-            yield from asyncio.sleep(1)
+            await asyncio.sleep(1)
         self.logger.debug("boostrapping with {}".format(self.bootstrap_nodes))
-        yield from self.kademlia.bootstrap(self.bootstrap_nodes)
+        await self.kademlia.bootstrap(self.bootstrap_nodes)
 
     def datagram_received(self, data, addr):
         ip_address, udp_port = addr
@@ -264,8 +263,7 @@ def _unpack(message):
 
 
 if __name__ == "__main__":
-    @asyncio.coroutine
-    def show_tasks():
+    async def show_tasks():
         while True:
             tasks = []
             for task in asyncio.Task.all_tasks():
@@ -273,7 +271,7 @@ if __name__ == "__main__":
                     tasks.append(task._coro.__name__)
             if tasks:
                 logger.debug("Active tasks: {}".format(tasks))
-            yield from asyncio.sleep(3)
+            await asyncio.sleep(3)
 
     config = {
         'privkey_hex': '65462b0520ef7d3df61b9992ed3bea0c56ead753be7c8b3614e0ce01e4cac41b',

--- a/evm/p2p/test_auth.py
+++ b/evm/p2p/test_auth.py
@@ -22,7 +22,7 @@ from evm.p2p.peer import BasePeer
 
 
 @pytest.mark.asyncio
-def test_handshake():
+async def test_handshake():
     # This data comes from https://gist.github.com/fjl/3a78780d17c755d22df2
     test_values = {
         "initiator_private_key": "5e173f6ac3c669587538e7727cf19b782a4f2fda07c1eaa662c593e5e85e3051",
@@ -141,8 +141,8 @@ def test_handshake():
 
     # The handshake msgs sent by each peer (above) are going to be fed directly into their remote's
     # reader, and thus the read_msg() calls will return immediately.
-    responder_hello = yield from responder_peer.read_msg()
-    initiator_hello = yield from initiator_peer.read_msg()
+    responder_hello = await responder_peer.read_msg()
+    initiator_hello = await initiator_peer.read_msg()
 
     cmd_id = rlp.decode(responder_hello[:1], sedes=sedes.big_endian_int)
     proto = responder_peer.get_protocol_for(cmd_id)


### PR DESCRIPTION
The generator-based coroutines have some limitations (e.g. not possible to yield values from them) and pitfalls that are not present on native coroutines. Since we don't intend to support python 3.4, there's no reason for us to use the generator-based approach