### PR TITLE
use hypothesis for random test

### DIFF
--- a/tests/database/test_chaindb.py
+++ b/tests/database/test_chaindb.py
@@ -1,6 +1,9 @@
-import os
-
 import pytest
+
+from hypothesis import (
+    given,
+    strategies as st,
+)
 
 import rlp
 
@@ -76,8 +79,9 @@ def test_persist_header_to_db(chaindb, header):
     assert chaindb.exists(number_to_hash_key)
 
 
-def test_persist_header_to_db_unknown_parent(chaindb, header):
-    header.parent_hash = keccak(os.urandom(32))
+@given(seed=st.binary(min_size=32, max_size=32))
+def test_persist_header_to_db_unknown_parent(chaindb, header, seed):
+    header.parent_hash = keccak(seed)
     with pytest.raises(ParentNotFound):
         chaindb.persist_header_to_db(header)
 


### PR DESCRIPTION
### What was wrong?

One of the chaindb tests was using `os.urandom` to provide testing randomness.  While this is a fine strategy, using hypothesis is arguably better for this type of test.

### How was it fixed?

Switched to use hypothesis to generate the randomness.

#### Cute Animal Picture

> put a cute animal picture here.

![47606](https://user-images.githubusercontent.com/824194/32669459-dbba664c-c5fd-11e7-8b22-c5848f79352f.jpg)
