### PR TITLE
Reduce CI parallelism from 3 to 2 cores

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 dist: trusty
 env:
   global:
-    - PYTEST_ADDOPTS="-n 3"
+    - PYTEST_ADDOPTS="-n 2"
   matrix:
     - TOX_POSARGS="-e py35-state-frontier"
     - TOX_POSARGS="-e py35-state-homestead"


### PR DESCRIPTION
### What was wrong?

The parallelism for CI was set to 3 cores.  During the Byzantium testing this was causing some of the workers to fail.  CI machines only actually have 2 cores.

### How was it fixed?

Changed to only use 2 workers

#### Cute Animal Picture

> put a cute animal picture here.

![6defea5741d3887ef69c4710b3c7047f](https://user-images.githubusercontent.com/824194/32906344-dbd58dee-cab9-11e7-812c-ef49b4b0f0d7.jpg)
