### PR TITLE
Add apply_child_computation to Computation object

### DIFF
--- a/evm/logic/call.py
+++ b/evm/logic/call.py
@@ -101,12 +101,7 @@ class BaseCall(Opcode):
 
             child_msg = computation.prepare_child_message(**child_msg_kwargs)
 
-            if child_msg.is_create:
-                child_computation = computation.vm.apply_create_message(child_msg)
-            else:
-                child_computation = computation.vm.apply_message(child_msg)
-
-            computation.children.append(child_computation)
+            child_computation = computation.apply_child_computation(child_msg)
 
             if child_computation.error:
                 computation.stack.push(0)

--- a/evm/logic/system.py
+++ b/evm/logic/system.py
@@ -141,8 +141,7 @@ class Create(Opcode):
             create_address=contract_address,
         )
 
-        child_computation = computation.vm.apply_create_message(child_msg)
-        computation.children.append(child_computation)
+        child_computation = computation.apply_child_computation(child_msg)
 
         if child_computation.error:
             computation.stack.push(0)

--- a/evm/vm/computation.py
+++ b/evm/vm/computation.py
@@ -171,6 +171,21 @@ class Computation(object):
     def output(self, value):
         self._output = value
 
+    #
+    # Runtime operations
+    #
+    def apply_child_computation(self, child_msg):
+        if child_msg.is_create:
+            child_computation = self.vm.apply_create_message(child_msg)
+        else:
+            child_computation = self.vm.apply_message(child_msg)
+
+        self.add_child_computation(child_computation)
+        return child_computation
+
+    def add_child_computation(self, child_computation):
+        self.children.append(child_computation)
+
     def register_account_for_deletion(self, beneficiary):
         validate_canonical_address(beneficiary, title="Suicide beneficiary address")
 


### PR DESCRIPTION
### What was wrong?

The way in which child computations were done left room for error.  It was possible to execute a child computation but fail to append it to the children of the parent computation.

### How was it fixed?

Added a new API onto the `Computation` object called `apply_child_computation` which has all of the necessary logic correctly grouped together for executing child messages.

#### Cute Animal Picture

![cute-puppy-pictures-028](https://user-images.githubusercontent.com/824194/32906939-ae12721c-cabb-11e7-89a2-4aa4b1e33d44.jpg)
