### PR TITLE
cleanup reason for CALLDATACOPY

### DIFF
--- a/evm/logic/context.py
+++ b/evm/logic/context.py
@@ -64,7 +64,7 @@ def calldatacopy(computation):
     word_count = ceil32(size) // 32
     copy_gas_cost = word_count * constants.GAS_COPY
 
-    computation.gas_meter.consume_gas(copy_gas_cost, reason="Data copy fee")
+    computation.gas_meter.consume_gas(copy_gas_cost, reason="CALLDATACOPY fee")
 
     value = computation.msg.data[calldata_start_position: calldata_start_position + size]
     padded_value = pad_right(value, size, b'\x00')


### PR DESCRIPTION
### What was wrong?

The logging message for the `CALLDATACOPY` gas usage didn't use consistent terminology

### How was it fixed?

Changed it to use `CALLDATACOPY` in the reason.

#### Cute Animal Picture

![6-112746-1ri1b5y-1438724398](https://user-images.githubusercontent.com/824194/32907279-bedc2b14-cabc-11e7-88c2-bde5e21cf67e.jpg)
