### PR TITLE
Add a repr method for BlockHeader object

### DIFF
--- a/evm/rlp/headers.py
+++ b/evm/rlp/headers.py
@@ -85,6 +85,12 @@ class BlockHeader(rlp.Serializable):
             nonce=nonce,
         )
 
+    def __repr__(self):
+        return '<BlockHeader #{0} {1}>'.format(
+            self.block_number,
+            encode_hex(self.hash)[2:10],
+        )
+
     @property
     def hash(self):
         return keccak(rlp.encode(self))


### PR DESCRIPTION
### What was wrong?

The `BlockHeader` object `repr` method was not implemented making the terminal representation not contain any useful information.

### How was it fixed?

Added a `__repr__` method that shows block number and hash for headers.

#### Cute Animal Picture

![tumblr_lysd5t8cmq1qgly11o1_500](https://user-images.githubusercontent.com/824194/32907761-6a4eb772-cabe-11e7-932d-cd0504091772.jpg)
