### PR TITLE
Piper/change receipt stateroot to binary

### DIFF
--- a/evm/rlp/receipts.py
+++ b/evm/rlp/receipts.py
@@ -4,6 +4,7 @@ import rlp
 from rlp.sedes import (
     big_endian_int,
     CountableList,
+    binary,
 )
 
 from eth_bloom import BloomFilter
@@ -11,7 +12,6 @@ from eth_bloom import BloomFilter
 from evm.exceptions import ValidationError
 
 from .sedes import (
-    trie_root,
     int256,
     int32,
 )
@@ -22,7 +22,7 @@ from .logs import Log
 class Receipt(rlp.Serializable):
 
     fields = [
-        ('state_root', trie_root),
+        ('state_root', binary),
         ('gas_used', big_endian_int),
         ('bloom', int256),
         ('logs', CountableList(Log))


### PR DESCRIPTION
### What was wrong?

The `state_root` field for receipts type was wrong.

### How was it fixed?

Changed it to use the `binary` sedes.

#### Cute Animal Picture

![mcmzbgt](https://user-images.githubusercontent.com/824194/32907826-b01064fe-cabe-11e7-9c8a-84444ca1c1c1.jpg)
