### PR TITLE
Improvements to padding utils

### DIFF
--- a/evm/utils/padding.py
+++ b/evm/utils/padding.py
@@ -1,6 +1,9 @@
-import functools
+from cytoolz import (
+    curry,
+)
 
 
+@curry
 def pad_left(value, to_size, pad_with):
     """
     Should be called to pad value to expected length
@@ -15,6 +18,7 @@ def pad_left(value, to_size, pad_with):
         return value
 
 
+@curry
 def pad_right(value, to_size, pad_with):
     """
     Should be called to pad value to expected length
@@ -29,5 +33,8 @@ def pad_right(value, to_size, pad_with):
         return value
 
 
-pad32 = functools.partial(pad_left, to_size=32, pad_with=b'\x00')
-pad32r = functools.partial(pad_right, to_size=32, pad_with=b'\x00')
+zpad_right = pad_right(pad_with=b'\x00')
+zpad_left = pad_left(pad_with=b'\x00')
+
+pad32 = zpad_left(to_size=32)
+pad32r = zpad_right(to_size=32)


### PR DESCRIPTION
### What was wrong?

Padding utils needed some easier to use APIs for common cases.

### How was it fixed?

Curried the main functions and then made some pre-curried helpers for common cases of left and right padding with zeros and to 32 bytes.

#### Cute Animal Picture

![a497b5a4bfba9cc96cb52ae231dc5ca9](https://user-images.githubusercontent.com/824194/32907914-1c24425a-cabf-11e7-8c0b-c6afcf0b3fd9.jpg)
