### PR TITLE
Move get_opcode_fn to Computation object

### DIFF
--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -13,9 +13,6 @@ from evm.constants import (
 from evm.exceptions import (
     Halt,
 )
-from evm.logic.invalid import (
-    InvalidOpcode,
-)
 from evm.utils.keccak import (
     keccak,
 )
@@ -138,7 +135,7 @@ class VM(object):
                 return computation
 
             for opcode in computation.code:
-                opcode_fn = self.get_opcode_fn(opcode)
+                opcode_fn = computation.get_opcode_fn(opcode)
 
                 computation.logger.trace(
                     "OPCODE: 0x%x (%s)",
@@ -330,12 +327,3 @@ class VM(object):
         been applied to a block.
         """
         self.chaindb.clear()
-
-    #
-    # Opcode API
-    #
-    def get_opcode_fn(self, opcode):
-        try:
-            return self.opcodes[opcode]
-        except KeyError:
-            return InvalidOpcode(opcode)

--- a/evm/vm/computation.py
+++ b/evm/vm/computation.py
@@ -8,6 +8,9 @@ from evm.constants import (
 from evm.exceptions import (
     VMError,
 )
+from evm.logic.invalid import (
+    InvalidOpcode,
+)
 from evm.validation import (
     validate_canonical_address,
     validate_uint256,
@@ -171,6 +174,9 @@ class Computation(object):
     def output(self, value):
         self._output = value
 
+    #
+    # Runtime operations
+    #
     def register_account_for_deletion(self, beneficiary):
         validate_canonical_address(beneficiary, title="Suicide beneficiary address")
 
@@ -187,6 +193,12 @@ class Computation(object):
             validate_uint256(topic, title="Log entry topic")
         validate_is_bytes(data, title="Log entry data")
         self.log_entries.append((account, topics, data))
+
+    def get_opcode_fn(self, opcode):
+        try:
+            return self.vm.opcodes[opcode]
+        except KeyError:
+            return InvalidOpcode(opcode)
 
     #
     # Getters


### PR DESCRIPTION
### What was wrong?

The `get_opcode_fn` was located on the VM class when it was better encapsulated by the `Computation` object.

### How was it fixed?

Moved `get_opcode_fn` to be a `Computation` object API.

#### Cute Animal Picture

![5f2de153220780ba060741ef107a1c34](https://user-images.githubusercontent.com/824194/32908058-9e7ddbf8-cabf-11e7-87a9-624a04753f5a.jpg)
