### PR TITLE
Refactory BaseVM initialization handling of chaindb

### DIFF
--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -35,18 +35,15 @@ class VM(object):
     individual VM classes for each fork of the protocol rules within that
     network.
     """
+    chaindb = None
     opcodes = None
     _block_class = None
     _precompiles = None
 
     def __init__(self, header, chaindb):
-        if chaindb is None:
-            raise ValueError("VM classes must have a `db`")
-
         self.chaindb = chaindb
-
         block_class = self.get_block_class()
-        self.block = block_class.from_header(header=header, chaindb=chaindb)
+        self.block = block_class.from_header(header=header, chaindb=self.chaindb)
 
     @classmethod
     def configure(cls,


### PR DESCRIPTION
### What was wrong?

During initialization of the `BaseVM` objects there was a check for whether the `chaindb` was `None`.  This was a carry-over from a previous version where the db was part of the class definition.

### How was it fixed?

Removed the check.

#### Cute Animal Picture

![395166785942e7f4098fb27b5dc8b3d2](https://user-images.githubusercontent.com/824194/32908215-2218f29a-cac0-11e7-8def-726203828b05.jpg)
