### PR TITLE
Add validation to computation.output

### DIFF
--- a/evm/vm/computation.py
+++ b/evm/vm/computation.py
@@ -169,6 +169,7 @@ class Computation(object):
 
     @output.setter
     def output(self, value):
+        validate_is_bytes(value)
         self._output = value
 
     def register_account_for_deletion(self, beneficiary):


### PR DESCRIPTION
### What was wrong?

The assignment of `Computation.output` did not do any type validation.

### How was it fixed?

Added validation that the assigned value is `bytes`.

#### Cute Animal Picture

![26 the easter corgi](https://user-images.githubusercontent.com/824194/32908315-6b6ffc86-cac0-11e7-9c76-2b4b202d2fcb.jpg)
