### PR TITLE
Rename gas_cost to gas_fee

### DIFF
--- a/evm/vm/forks/frontier/__init__.py
+++ b/evm/vm/forks/frontier/__init__.py
@@ -50,12 +50,12 @@ def _execute_frontier_transaction(vm, transaction):
 
     vm.validate_transaction(transaction)
 
-    gas_cost = transaction.gas * transaction.gas_price
+    gas_fee = transaction.gas * transaction.gas_price
     with vm.state_db() as state_db:
         sender_balance = state_db.get_balance(transaction.sender)
 
         # Buy Gas
-        state_db.set_balance(transaction.sender, sender_balance - gas_cost)
+        state_db.set_balance(transaction.sender, sender_balance - gas_fee)
 
         # Increment Nonce
         state_db.increment_nonce(transaction.sender)
@@ -251,10 +251,10 @@ def _apply_frontier_create_message(vm, message):
         contract_code = computation.output
 
         if contract_code:
-            contract_code_gas_cost = len(contract_code) * constants.GAS_CODEDEPOSIT
+            contract_code_gas_fee = len(contract_code) * constants.GAS_CODEDEPOSIT
             try:
                 computation.gas_meter.consume_gas(
-                    contract_code_gas_cost,
+                    contract_code_gas_fee,
                     reason="Write contract code for CREATE",
                 )
             except OutOfGas:


### PR DESCRIPTION
### What was wrong?

The term `gas_cost` was being used where elsewhere these are referred to as `gas_fee`

### How was it fixed?

Renamed the variable to use `gas_fee`

#### Cute Animal Picture

![965cae651b6bdc30773be190247705a8--baby-corgi-corgi-pups](https://user-images.githubusercontent.com/824194/32908602-382f7f12-cac1-11e7-937e-539235fb3295.jpg)
